### PR TITLE
Add GEO foundation and evergreen content workflow

### DIFF
--- a/.brain/context/architecture.md
+++ b/.brain/context/architecture.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-17T18:10:51Z"
+updated: "2026-04-17T21:02:47Z"
 ---
 # Architecture
 
@@ -17,5 +17,6 @@ Use this file for the structural shape of the repository.
 - GEO metadata is now centralized in `src/lib/seo.ts`, which supplies canonical, social, and JSON-LD data to home, archive, post, and topic routes.
 - Canonical content subjects now live in `topics` frontmatter plus `src/lib/taxonomy.ts`; `categories` remain tag/archive metadata and legacy typo slugs redirect to normalized category URLs.
 - Topic hubs now live under `/topics` with prerendered topic pages and post-to-topic navigation. Keep sitemap generation aligned with `src/lib/taxonomy.ts` as topics evolve.
+- `/topics` now loads derived topic overview metadata from `src/routes/topics/+page.ts`, while `/topics/[topic]` stays prerendered and enhances browsing on the client with URL-synced `q` and `page` state. Keep query-state logic browser-only so prerendering stays valid.
 - The public post view counter was intentionally removed from `src/routes/blog/[slug]/+page.svelte` because the prerendered zero-state was misleading. Keep Plausible or the views API for internal reporting unless a trustworthy hydrated counter is reintroduced.
 Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/architecture.md
+++ b/.brain/context/architecture.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-04-17T18:10:51Z"
+---
 # Architecture
 
 <!-- brain:begin context-architecture -->
@@ -11,4 +14,8 @@ Use this file for the structural shape of the repository.
 
 ## Local Notes
 
+- GEO metadata is now centralized in `src/lib/seo.ts`, which supplies canonical, social, and JSON-LD data to home, archive, post, and topic routes.
+- Canonical content subjects now live in `topics` frontmatter plus `src/lib/taxonomy.ts`; `categories` remain tag/archive metadata and legacy typo slugs redirect to normalized category URLs.
+- Topic hubs now live under `/topics` with prerendered topic pages and post-to-topic navigation. Keep sitemap generation aligned with `src/lib/taxonomy.ts` as topics evolve.
+- The public post view counter was intentionally removed from `src/routes/blog/[slug]/+page.svelte` because the prerendered zero-state was misleading. Keep Plausible or the views API for internal reporting unless a trustworthy hydrated counter is reintroduced.
 Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-18T00:53:12Z"
+updated: "2026-04-18T01:07:20Z"
 ---
 # Current State
 

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-17T23:41:15Z"
+updated: "2026-04-18T00:53:12Z"
 ---
 # Current State
 
@@ -43,3 +43,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - `bun run lint` still fails because the repo already has broad Prettier drift in untouched files. The Bun migration itself was validated with `bun install`, `bun run check`, `bun run build`, `bun run start`, `docker build`, and an HTTP smoke test against the built container.
 - GEO foundation work is now staged on `feat/geo-evergreen-system`: shared SEO helpers, JSON-LD, `robots.txt`, expanded sitemap coverage, normalized category redirects, topic hubs under `/topics`, evergreen content workflow docs, and the first refreshed post cohort seed in `src/posts/cat-grep-and-go.md`.
 - The blog archive header at `src/routes/blog/+page.svelte` now uses the same quieter archive-control language as the topic pages: one integrated surface for search, page status, and the topic-hub CTA instead of separate promo and pagination blocks.
+- Paginated archive views in `src/routes/blog/+page.svelte` and `src/routes/topics/[topic]/+page.svelte` now render `PaginationNav` above and below the list so the page controls remain visible without scrolling to the footer.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-18T01:07:20Z"
+updated: "2026-04-18T01:21:15Z"
 ---
 # Current State
 

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,5 +1,5 @@
 ---
-updated: "2026-04-17T18:13:10Z"
+updated: "2026-04-17T23:41:15Z"
 ---
 # Current State
 
@@ -42,3 +42,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - The remaining migration follow-up is outside the repo: switch the Coolify app from Nixpacks to Dockerfile mode and point preview plus production deploys at the repo `Dockerfile`.
 - `bun run lint` still fails because the repo already has broad Prettier drift in untouched files. The Bun migration itself was validated with `bun install`, `bun run check`, `bun run build`, `bun run start`, `docker build`, and an HTTP smoke test against the built container.
 - GEO foundation work is now staged on `feat/geo-evergreen-system`: shared SEO helpers, JSON-LD, `robots.txt`, expanded sitemap coverage, normalized category redirects, topic hubs under `/topics`, evergreen content workflow docs, and the first refreshed post cohort seed in `src/posts/cat-grep-and-go.md`.
+- The blog archive header at `src/routes/blog/+page.svelte` now uses the same quieter archive-control language as the topic pages: one integrated surface for search, page status, and the topic-hub CTA instead of separate promo and pagination blocks.

--- a/.brain/context/current-state.md
+++ b/.brain/context/current-state.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-04-17T18:13:10Z"
+---
 # Current State
 
 <!-- brain:begin context-current-state -->
@@ -38,3 +41,4 @@ Add repo-specific notes here. `brain context refresh` preserves content outside 
 - The Bun migration changed the active repo boundaries around `package.json`, `bunfig.toml`, `Dockerfile`, `.dockerignore`, `README.md`, `docs/project-*.md`, and `.brain/context/*.md`. Treat those files as the primary runtime and deployment contract for future work.
 - The remaining migration follow-up is outside the repo: switch the Coolify app from Nixpacks to Dockerfile mode and point preview plus production deploys at the repo `Dockerfile`.
 - `bun run lint` still fails because the repo already has broad Prettier drift in untouched files. The Bun migration itself was validated with `bun install`, `bun run check`, `bun run build`, `bun run start`, `docker build`, and an HTTP smoke test against the built container.
+- GEO foundation work is now staged on `feat/geo-evergreen-system`: shared SEO helpers, JSON-LD, `robots.txt`, expanded sitemap coverage, normalized category redirects, topic hubs under `/topics`, evergreen content workflow docs, and the first refreshed post cohort seed in `src/posts/cat-grep-and-go.md`.

--- a/.brain/context/workflows.md
+++ b/.brain/context/workflows.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-04-17T17:39:07Z"
+---
 # Workflows
 
 <!-- brain:begin context-workflows -->
@@ -42,6 +45,7 @@ Use this file for agent operating workflow inside the repo.
 
 ## Local Notes
 
+- `.plan/` is now the repo-local planning workspace. Use it for brainstorms, epics, specs, stories, and roadmap work such as GEO planning before implementation starts.
 Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
 
 - Bun is the default tool for installs, scripts, and one-off CLIs in this repo. Prefer `bun install`, `bun run <script>`, and `bunx <tool>` in examples and operational guidance.

--- a/.brain/resources/changes/add-top-pagination-to-all-paginated-archive-lists.md
+++ b/.brain/resources/changes/add-top-pagination-to-all-paginated-archive-lists.md
@@ -1,0 +1,12 @@
+---
+created: "2026-04-18T00:53:46Z"
+title: Add top pagination to all paginated archive lists
+type: change_note
+updated: "2026-04-18T00:53:46Z"
+---
+# Add top pagination to all paginated archive lists
+
+## Verification
+
+- `bun run check`
+- `bun run build`

--- a/.plan/.meta/migrations.json
+++ b/.plan/.meta/migrations.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "known": [],
+  "last_run_at": "2026-04-17T17:35:16Z",
+  "status": "current",
+  "last_operation": "adopt",
+  "last_created": [
+    ".plan",
+    ".plan/brainstorms",
+    ".plan/epics",
+    ".plan/specs",
+    ".plan/stories",
+    ".plan/.meta",
+    ".plan/PROJECT.md",
+    ".plan/ROADMAP.md",
+    ".plan/.meta/workspace.json",
+    ".plan/.meta/migrations.json"
+  ],
+  "history": [
+    {
+      "operation": "adopt",
+      "at": "2026-04-17T17:35:16Z",
+      "status": "current",
+      "created": [
+        ".plan",
+        ".plan/brainstorms",
+        ".plan/epics",
+        ".plan/specs",
+        ".plan/stories",
+        ".plan/.meta",
+        ".plan/PROJECT.md",
+        ".plan/ROADMAP.md",
+        ".plan/.meta/workspace.json",
+        ".plan/.meta/migrations.json"
+      ]
+    }
+  ]
+}

--- a/.plan/.meta/workspace.json
+++ b/.plan/.meta/workspace.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "planning_model": "epic_spec_story_v1",
+  "created_at": "2026-04-17T17:35:16Z",
+  "updated_at": "2026-04-17T17:35:16Z"
+}

--- a/.plan/PROJECT.md
+++ b/.plan/PROJECT.md
@@ -1,0 +1,39 @@
+# Project: personal-blog
+
+Created: 2026-04-17T17:35:16Z
+
+## Vision
+
+Turn `jimmymcbride.dev` from a chronological post archive into a durable developer knowledge base that search engines and generative engines can crawl, understand, cite, and revisit.
+
+## Principles
+
+- Own-domain first. Publish, measure, and canonicalize on `jimmymcbride.dev` before syndication.
+- Fix platform truth before scaling content. Broken canonicals, missing crawl surfaces, and thin archives block everything downstream.
+- Prefer reusable systems over one-off page tweaks. Shared metadata helpers, taxonomy maps, and editorial checklists beat per-post heroics.
+- Keep voice and first-hand experience. GEO should improve extractability, not flatten the writing into generic SEO copy.
+- Optimize for evergreen upkeep. Every new workflow should also make old posts easier to refresh.
+
+## Constraints
+
+- Solo-maintained SvelteKit blog running on Bun.
+- Existing content lives in `src/posts/*.md` with lightweight frontmatter and mdsvex rendering.
+- Current production analytics surface is Plausible plus a route-scoped views API.
+- Search Console, Bing Webmaster Tools, and IndexNow require off-repo setup and verification.
+- Avoid fake capabilities. Do not ship `SearchAction`, `llms.txt`, or automation surfaces until the site actually supports them.
+
+## Planning Rules
+
+- Specs are the canonical execution contract.
+- Stories are created only after spec approval.
+- Stories should be execution-ready and verification-aware.
+
+## Notes
+
+- Current GEO plan is organized around five epics:
+  - technical foundation
+  - shared SEO and structured data
+  - taxonomy and topic hubs
+  - evergreen content operations
+  - measurement, refresh, and syndication
+- First implementation wave should stay focused on foundation plus shared SEO. Taxonomy cleanup and editorial systems build on those surfaces.

--- a/.plan/ROADMAP.md
+++ b/.plan/ROADMAP.md
@@ -1,0 +1,60 @@
+# Roadmap: personal-blog
+
+Created: 2026-04-17T17:35:16Z
+
+## Overview
+
+Near-term GEO work should follow a strict order:
+
+1. Fix crawlability and metadata truth.
+2. Normalize taxonomy and page architecture.
+3. Install repeatable content and refresh workflows.
+4. Measure results and tighten syndication loops.
+
+## v1: Core
+
+Goal:
+
+Ship the technical and metadata foundation required for reliable crawlability, correct canonicals, and machine-readable post pages.
+
+Summary:
+
+- Establish GEO technical foundation.
+- Build shared SEO and structured data system.
+- Document external dashboard and crawler-policy setup work that cannot live purely in code.
+
+## v2: Rigor
+
+Goal:
+
+Turn the archive into a topic graph with durable editorial process for both net-new and refreshed content.
+
+Summary:
+
+- Normalize taxonomy and launch first topic hubs.
+- Create evergreen content operations workflow.
+- Refresh a small set of high-value posts using the new workflow.
+
+## v3: Power
+
+Goal:
+
+Close the loop between publishing, measurement, refresh, and syndication so the system compounds instead of drifting.
+
+Summary:
+
+- Instrument measurement, refresh, and syndication loops.
+- Add KPI review cadence and candidate scoring for refreshes.
+- Systematize DEV and off-site summary workflows.
+
+## Ordering Notes
+
+- Do not launch topic hubs before canonical taxonomy exists.
+- Do not automate syndication before canonicals, sitemap, and referral measurement are trustworthy.
+- Do not publish a `SearchAction` schema block until a real `/search` route exists.
+
+## Parking Lot
+
+- `llms.txt` policy once crawler/access stance is clearer.
+- Search route and search UX.
+- Automated stale-content detection if manual refresh review becomes too noisy.

--- a/.plan/brainstorms/geo-and-evergreen-content-system-for-personal-blog.md
+++ b/.plan/brainstorms/geo-and-evergreen-content-system-for-personal-blog.md
@@ -1,0 +1,55 @@
+---
+created_at: "2026-04-17T17:35:20Z"
+project: personal-blog
+slug: geo-and-evergreen-content-system-for-personal-blog
+status: active
+title: GEO and evergreen content system for personal-blog
+type: brainstorm
+updated_at: "2026-04-17T17:35:35Z"
+---
+
+# Brainstorm: GEO and evergreen content system for personal-blog
+
+Started: 2026-04-17T17:35:20Z
+
+## Focus Question
+
+How should `personal-blog` evolve so the current SvelteKit codebase supports GEO/SEO fundamentals, evergreen refreshes, and durable content operations instead of one-off manual post publishing?
+
+## Desired Outcome
+
+A repo-local planning stack that converts the research doc into executable epics and specs tied to real files, routes, and workflows in this codebase.
+
+## Constraints
+
+- Existing content source is markdown in `src/posts/*.md`.
+- Current site architecture is prerender-heavy and route metadata is hand-authored in Svelte components.
+- Solo-maintained. Workflow overhead must stay low.
+- Some required wins live outside the repo: Search Console, Bing, IndexNow, and analytics dashboard setup.
+
+## Open Questions
+
+- Should the public `Total Views` counter stay on post pages if Plausible data cannot hydrate reliably?
+- Do we want category pages to remain public as aliases once topic hubs exist, or should they redirect?
+- Is an `/about` or `/author` route the preferred source for `Person`/`ProfilePage` schema?
+- Which 5 to 7 canonical topics should replace the current raw category sprawl?
+- Which existing posts should form the first refresh cohort?
+
+## Ideas
+
+- Create a shared SEO metadata system for routes and posts. Current gaps: broken canonical on src/routes/blog/[slug]/+page.svelte, repeated head tags across home/blog pages, no route metadata on category pages.
+
+- Add structured data generation for WebSite, BlogPosting, BreadcrumbList, and Person/ProfilePage. Current repo has no JSON-LD output in src/.
+
+- Strengthen crawl/discovery surfaces. Current repo has src/routes/sitemap.xml/+server.ts and rss.xml, but no robots.txt, sitemap only includes post URLs, and SearchAction should wait until a real /search route exists.
+
+- Normalize taxonomy and topic architecture. Frontmatter categories in src/posts/*.md include drift and typos like texutal-healing, tutoiral, careerdevelopment. Category archive pages are thin and need promotion into topic hubs.
+
+- Build evergreen editorial workflow around source packs, answer-first intros, FAQ/common-mistakes blocks, internal-link targets, and updated-date refreshes. This should become a repeatable authoring checklist plus prompt pack stored in repo docs.
+
+- Create refresh workflow for existing posts before scaling net-new content. Use high-value candidates like sveltekit-blog, cat-grep-and-go, self-host-your-digital-empire, and devto hacks to prove lift first.
+
+- Fix measurement and reporting. Plausible exists in layout and views API, but public Total Views shows 0 on prerendered posts. Need referral grouping for AI/search, pageview integrity, and a lightweight KPI dashboard spec.
+
+- Define syndication workflow for DEV and off-site summaries. Goal: own-domain first, canonical-safe reposts, teaser templates, and publish/checklist hooks so cross-posting supports GEO instead of cannibalizing it.
+## Raw Notes

--- a/.plan/epics/build-shared-seo-and-structured-data-system.md
+++ b/.plan/epics/build-shared-seo-and-structured-data-system.md
@@ -1,0 +1,53 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+project: personal-blog
+slug: build-shared-seo-and-structured-data-system
+spec: build-shared-seo-and-structured-data-system
+title: Build shared SEO and structured data system
+type: epic
+updated_at: "2026-04-17T17:35:50Z"
+---
+
+# Build shared SEO and structured data system
+
+Created: 2026-04-17T17:35:50Z
+
+## Outcome
+
+A single shared metadata layer that generates correct canonical, Open Graph, Twitter, and JSON-LD output across home, blog index, post pages, and category/topic surfaces.
+
+## Why Now
+
+Current metadata is duplicated across routes, and the post page canonical is broken in `src/routes/blog/[slug]/+page.svelte` by composing `${url}${url}` instead of a post URL. The repo also has no JSON-LD output, which makes machine-readable authorship and page-type signals weak.
+
+## Scope Boundary
+
+- In scope:
+  - shared SEO helpers
+  - fixed canonical/OG/Twitter tags
+  - JSON-LD for `WebSite`, `BlogPosting`, and breadcrumb-like page context
+- Out of scope:
+  - rewriting article copy
+  - external indexing dashboards
+  - building search
+
+## Spec
+
+`./.plan/specs/build-shared-seo-and-structured-data-system.md`
+
+## Resources
+
+- `src/lib/config.ts`
+- `src/routes/+page.svelte`
+- `src/routes/blog/+page.svelte`
+- `src/routes/blog/[slug]/+page.svelte`
+- `src/routes/blog/categories/[category]/+page.svelte`
+
+## Progress
+
+Drafted. Canonical bug confirmed during discovery.
+
+## Notes
+
+- This epic should produce reusable utilities, not more hand-authored `<svelte:head>` duplication.
+- `ProfilePage` schema should wait for a stable author page route or be scoped carefully.

--- a/.plan/epics/create-evergreen-content-operations-workflow.md
+++ b/.plan/epics/create-evergreen-content-operations-workflow.md
@@ -1,0 +1,53 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+project: personal-blog
+slug: create-evergreen-content-operations-workflow
+spec: create-evergreen-content-operations-workflow
+title: Create evergreen content operations workflow
+type: epic
+updated_at: "2026-04-17T17:35:50Z"
+---
+
+# Create evergreen content operations workflow
+
+Created: 2026-04-17T17:35:50Z
+
+## Outcome
+
+A documented, low-friction content system for new posts and refreshes that enforces answer-first structure, source packs, internal linking, and freshness maintenance without losing author voice.
+
+## Why Now
+
+The research doc is strongest where it proposes workflows and prompt structure, but none of that is encoded in repo docs today. Without a reusable authoring system, the site will keep drifting into inconsistent intros, weak citations, and one-off publishing habits.
+
+## Scope Boundary
+
+- In scope:
+  - authoring checklist
+  - refresh checklist
+  - prompt pack and template docs
+  - frontmatter/content requirements for evergreen updates
+- Out of scope:
+  - fully automated article generation
+  - CMS migration
+  - deep analytics implementation
+
+## Spec
+
+`./.plan/specs/create-evergreen-content-operations-workflow.md`
+
+## Resources
+
+- Research doc prompt templates
+- `src/posts/*.md`
+- `docs/`
+- `.brain/context/workflows.md`
+
+## Progress
+
+Drafted. Needs concrete deliverable docs before stories exist.
+
+## Notes
+
+- This epic should support both “new post” and “refresh old post” flows.
+- Source-backed drafting matters more than model choice.

--- a/.plan/epics/establish-geo-technical-foundation.md
+++ b/.plan/epics/establish-geo-technical-foundation.md
@@ -1,0 +1,52 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+project: personal-blog
+slug: establish-geo-technical-foundation
+spec: establish-geo-technical-foundation
+title: Establish GEO technical foundation
+type: epic
+updated_at: "2026-04-17T17:35:50Z"
+---
+
+# Establish GEO technical foundation
+
+Created: 2026-04-17T17:35:50Z
+
+## Outcome
+
+Reliable crawl and discovery surfaces for the site: accurate sitemap coverage, explicit crawler policy, and a documented external setup checklist for search/indexing platforms.
+
+## Why Now
+
+The current repo already exposes `src/routes/sitemap.xml/+server.ts`, but it only emits post URLs. There is no `robots.txt`, and external verification/setup steps are not captured in repo planning. Content and taxonomy work will compound poorly until these basics are trustworthy.
+
+## Scope Boundary
+
+- In scope:
+  - sitemap coverage for core routes
+  - crawler policy and `robots.txt`
+  - external setup checklist for Search Console, Bing, and IndexNow
+- Out of scope:
+  - full analytics architecture
+  - post-level schema generation
+  - topic hub content strategy
+
+## Spec
+
+`./.plan/specs/establish-geo-technical-foundation.md`
+
+## Resources
+
+- `src/routes/sitemap.xml/+server.ts`
+- `src/routes/rss.xml/+server.ts`
+- `src/routes/api/posts/+server.ts`
+- Research doc sections on robots, sitemap, crawler policy, and IndexNow
+
+## Progress
+
+Drafted. No implementation stories yet.
+
+## Notes
+
+- Treat `robots.txt` and sitemap as deployment truth, not marketing afterthoughts.
+- SearchAction schema explicitly belongs to a later phase because the repo has no `/search` route today.

--- a/.plan/epics/instrument-measurement-refresh-and-syndication-loops.md
+++ b/.plan/epics/instrument-measurement-refresh-and-syndication-loops.md
@@ -1,0 +1,53 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+project: personal-blog
+slug: instrument-measurement-refresh-and-syndication-loops
+spec: instrument-measurement-refresh-and-syndication-loops
+title: Instrument measurement, refresh, and syndication loops
+type: epic
+updated_at: "2026-04-17T17:35:50Z"
+---
+
+# Instrument measurement, refresh, and syndication loops
+
+Created: 2026-04-17T17:35:50Z
+
+## Outcome
+
+A lightweight measurement system tied to publishing and refresh decisions, plus a repeatable syndication workflow that protects own-domain authority.
+
+## Why Now
+
+The repo already includes Plausible in `src/routes/+layout.svelte` and a views API in `src/routes/api/views/[slug]/+server.ts`, but public post pages can still show `Total Views: 0`. That makes measurement trust shaky. The site also has no repo-local plan for refresh scoring or DEV syndication discipline.
+
+## Scope Boundary
+
+- In scope:
+  - analytics integrity decisions
+  - KPI and review cadence
+  - refresh candidate scoring/process
+  - syndication checklist for DEV and similar channels
+- Out of scope:
+  - full BI stack
+  - rewriting all old posts
+  - crawler policy and sitemap basics
+
+## Spec
+
+`./.plan/specs/instrument-measurement-refresh-and-syndication-loops.md`
+
+## Resources
+
+- `src/routes/+layout.svelte`
+- `src/routes/api/views/[slug]/+server.ts`
+- `src/routes/blog/[slug]/+page.ts`
+- `src/posts/the-ultimate-devto-hacks.md`
+
+## Progress
+
+Drafted. Public view-count issue confirmed during discovery.
+
+## Notes
+
+- If a metric cannot be trusted, remove or hide it until fixed.
+- Syndication rules should be documented next to the authoring workflow, not remembered ad hoc.

--- a/.plan/epics/normalize-taxonomy-and-launch-topic-hubs.md
+++ b/.plan/epics/normalize-taxonomy-and-launch-topic-hubs.md
@@ -1,0 +1,53 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+project: personal-blog
+slug: normalize-taxonomy-and-launch-topic-hubs
+spec: normalize-taxonomy-and-launch-topic-hubs
+title: Normalize taxonomy and launch topic hubs
+type: epic
+updated_at: "2026-04-17T17:35:50Z"
+---
+
+# Normalize taxonomy and launch topic hubs
+
+Created: 2026-04-17T17:35:50Z
+
+## Outcome
+
+A canonical topic model for the blog plus hub pages that explain each topic, group related posts, and replace thin archive behavior with deliberate information architecture.
+
+## Why Now
+
+Post frontmatter contains typo and drift categories such as `texutal-healing`, `tutoiral`, and `careerdevelopment`. Current category pages only filter posts and render a heading, which is too thin for strong topic retrieval.
+
+## Scope Boundary
+
+- In scope:
+  - category inventory and normalization map
+  - canonical topic set
+  - hub/page architecture
+  - alias or redirect strategy for old category URLs
+- Out of scope:
+  - large-scale content rewriting
+  - automated semantic clustering infrastructure
+  - cross-site taxonomy governance
+
+## Spec
+
+`./.plan/specs/normalize-taxonomy-and-launch-topic-hubs.md`
+
+## Resources
+
+- `src/posts/*.md`
+- `src/routes/blog/categories/[category]/+page.ts`
+- `src/routes/blog/categories/[category]/+page.svelte`
+- brainstorm category inventory from 2026-04-17
+
+## Progress
+
+Drafted. Category inventory complete enough to start canonical mapping.
+
+## Notes
+
+- First hubs should align with actual post gravity, not idealized future topics.
+- Hub rollout should feed sitemap coverage work in the foundation epic.

--- a/.plan/specs/build-shared-seo-and-structured-data-system.md
+++ b/.plan/specs/build-shared-seo-and-structured-data-system.md
@@ -1,0 +1,99 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+epic: build-shared-seo-and-structured-data-system
+project: personal-blog
+slug: build-shared-seo-and-structured-data-system
+status: done
+title: Build shared SEO and structured data system Spec
+type: spec
+updated_at: "2026-04-17T18:10:19Z"
+---
+
+# Build shared SEO and structured data system Spec
+
+Created: 2026-04-17T17:35:50Z
+
+## Why
+
+Metadata is currently fragmented and error-prone. A shared layer will fix correctness issues once and make future routes cheaper to ship.
+
+## Problem
+
+- Home and blog index hand-roll similar head tags.
+- Category pages have no metadata.
+- Post page canonical and `og:url` are incorrect.
+- No JSON-LD output exists for site or article pages.
+
+## Goals
+
+- Centralize canonical/OG/Twitter generation.
+- Fix post canonical correctness.
+- Add JSON-LD for `WebSite` and `BlogPosting`.
+- Add route-aware metadata to category/topic pages and future author surfaces.
+
+## Non-Goals
+
+- Rewriting post content.
+- Implementing on-site search.
+- Shipping schema types the site cannot support honestly.
+
+## Constraints
+
+- Post metadata comes from mdsvex frontmatter.
+- Some fields are inconsistent today, especially around category quality and optional short descriptions.
+- SearchAction must remain out until `/search` exists.
+
+## Solution Shape
+
+- Add shared SEO utility functions or a small metadata module under `src/lib/`.
+- Build route-level helpers that derive canonical URLs from slug/path instead of string duplication.
+- Render JSON-LD blocks from typed data on home and post pages.
+- Prepare breadcrumb-compatible data for blog and topic navigation.
+
+## Flows
+
+- Route loads content or config.
+- Metadata helper derives canonical URL, title, description, social image, and schema payload.
+- Svelte page renders one shared head pattern plus optional JSON-LD blocks.
+
+## Data / Interfaces
+
+- `Post` frontmatter fields: `title`, `description`, `short`, `date`, `updated`, `image`, `categories`, `slug`.
+- Site config fields from `src/lib/config.ts`.
+- Route path context for blog index, category pages, and future hubs.
+
+## Risks / Open Questions
+
+- A proper author/about route may be needed before `ProfilePage` schema feels complete.
+- Some posts may need metadata cleanup before schema generation is safe.
+
+## Rollout
+
+1. Fix post canonical and create shared helper.
+2. Migrate home and blog index to shared helper.
+3. Add category/topic metadata.
+4. Add JSON-LD surfaces.
+
+## Verification
+
+- `bun run check`
+- `bun run build`
+- Inspect generated HTML head output for representative routes.
+
+## Story Breakdown
+
+- Story 1: Create shared SEO metadata helper.
+- Story 2: Migrate post route and fix canonical bug.
+- Story 3: Add metadata to archive pages.
+- Story 4: Add JSON-LD site and article payloads.
+
+## Resources
+
+- `src/routes/+page.svelte`
+- `src/routes/blog/+page.svelte`
+- `src/routes/blog/[slug]/+page.svelte`
+- `src/lib/config.ts`
+
+## Notes
+
+- Shared helper should reduce future drift, not just patch today’s bug.

--- a/.plan/specs/create-evergreen-content-operations-workflow.md
+++ b/.plan/specs/create-evergreen-content-operations-workflow.md
@@ -1,0 +1,98 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+epic: create-evergreen-content-operations-workflow
+project: personal-blog
+slug: create-evergreen-content-operations-workflow
+status: done
+title: Create evergreen content operations workflow Spec
+type: spec
+updated_at: "2026-04-17T18:10:19Z"
+---
+
+# Create evergreen content operations workflow Spec
+
+Created: 2026-04-17T17:35:50Z
+
+## Why
+
+The research doc is most valuable when it becomes a repeatable workflow. Without repo-local guidance, good ideas about source packs, answer-first intros, and refresh habits will keep getting lost between posts.
+
+## Problem
+
+- No durable authoring workflow exists in repo docs.
+- Post structure and intro quality vary widely.
+- There is no standard refresh process for old content.
+- Prompt ideas live in a chat artifact, not in the project.
+
+## Goals
+
+- Document a repeatable new-post workflow.
+- Document a repeatable refresh workflow.
+- Capture prompt templates and review gates in repo docs.
+- Define evergreen content requirements: answer-first intro, internal-link targets, FAQ/common mistakes, update handling, and source-backed claims.
+
+## Non-Goals
+
+- Full CMS/editor build-out.
+- Automatic content generation without human review.
+- Heavy tooling before the workflow proves useful.
+
+## Constraints
+
+- Workflow must stay light enough for solo maintenance.
+- Must preserve Jimmy’s voice and first-hand experience.
+- Source-backed drafting is required for factual or security-sensitive claims.
+
+## Solution Shape
+
+- Add a content operations doc under `docs/`.
+- Add prompt pack and checklist templates that work for both new articles and refreshes.
+- Define minimum frontmatter and on-page structural expectations.
+- Connect the workflow to taxonomy and syndication rules from adjacent epics.
+
+## Flows
+
+- New post flow: topic -> source pack -> outline -> draft -> review gates -> publish -> syndicate.
+- Refresh flow: query target -> current post audit -> source refresh -> rewrite -> verify links/meta -> republish.
+
+## Data / Interfaces
+
+- Source pack
+- Target queries
+- Internal link targets
+- Refresh date / updated field
+- Syndication checklist inputs
+
+## Risks / Open Questions
+
+- Too much process could slow publishing unless templates are concise.
+- Need decision on where prompt templates should live for easiest reuse.
+
+## Rollout
+
+1. Draft the workflow docs and templates.
+2. Test on one new-post outline and one refresh.
+3. Trim friction based on real usage.
+
+## Verification
+
+- Dry-run the workflow against at least one existing post.
+- Verify docs are specific enough to execute without extra explanation.
+
+## Story Breakdown
+
+- Story 1: Write content operations guide.
+- Story 2: Add new-post prompt/checklist pack.
+- Story 3: Add refresh prompt/checklist pack.
+- Story 4: Test workflow on first refresh cohort.
+
+## Resources
+
+- GEO research doc prompt sections
+- `src/posts/sveltekit-blog.md`
+- `src/posts/cat-grep-and-go.md`
+- `src/posts/self-host-your-digital-empire.md`
+
+## Notes
+
+- This spec is the bridge between strategy and day-to-day publishing behavior.

--- a/.plan/specs/establish-geo-technical-foundation.md
+++ b/.plan/specs/establish-geo-technical-foundation.md
@@ -1,0 +1,99 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+epic: establish-geo-technical-foundation
+project: personal-blog
+slug: establish-geo-technical-foundation
+status: done
+title: Establish GEO technical foundation Spec
+type: spec
+updated_at: "2026-04-17T18:10:19Z"
+---
+
+# Establish GEO technical foundation Spec
+
+Created: 2026-04-17T17:35:50Z
+
+## Why
+
+Content quality improvements will underperform until the site exposes accurate crawl and discovery signals to both search engines and AI-facing search crawlers.
+
+## Problem
+
+- No `robots.txt` exists in `static/`.
+- `src/routes/sitemap.xml/+server.ts` only emits blog post URLs.
+- External setup work for Search Console, Bing Webmaster Tools, and IndexNow is not captured in repo planning.
+- The repo lacks an explicit documented crawler policy for search bots versus training bots.
+
+## Goals
+
+- Serve an explicit `robots.txt` and sitemap strategy.
+- Expand sitemap coverage to include core canonical routes.
+- Define a crawler access policy aligned with GEO goals.
+- Capture external platform setup as a repo-local checklist or operating doc.
+
+## Non-Goals
+
+- Adding `SearchAction` schema before a real `/search` route exists.
+- Deep analytics event design.
+- Content rewriting.
+
+## Constraints
+
+- Site is SvelteKit on Bun with prerendered surfaces.
+- Some work is operational, not code-only.
+- Taxonomy normalization may change which category or hub URLs belong in sitemap later.
+
+## Solution Shape
+
+- Add a crawl policy surface, likely `static/robots.txt`.
+- Refactor sitemap generation so it includes core static routes and expandable content routes.
+- Add documentation for off-repo platform setup and revalidation steps.
+- Leave `llms.txt` out until there is a clear reason and policy for it.
+
+## Flows
+
+- Deploy or refresh content.
+- Validate sitemap and robots output.
+- Submit or verify via Search Console/Bing/IndexNow.
+- Re-check indexed/canonical status after material changes.
+
+## Data / Interfaces
+
+- Core route list: `/`, `/blog`, RSS, categories or future topics.
+- Content route list from `src/routes/api/posts/+server.ts`.
+- Future topic route list from taxonomy config once that epic lands.
+
+## Risks / Open Questions
+
+- IndexNow requires key management and endpoint design outside current repo state.
+- Category route inclusion in sitemap may churn until taxonomy is normalized.
+- Need user decision on whether to block training bots while allowing search bots.
+
+## Rollout
+
+1. Add crawl policy docs and route/file surfaces.
+2. Expand sitemap coverage.
+3. Verify outputs locally and in production.
+4. Complete off-repo platform checklist.
+
+## Verification
+
+- `bun run build`
+- Inspect generated `robots.txt` and `sitemap.xml` output locally or in build artifacts.
+- Manual curl/browser checks against deployed endpoints.
+
+## Story Breakdown
+
+- Story 1: Add and document crawler policy surface.
+- Story 2: Expand sitemap coverage and stable URL sources.
+- Story 3: Add external search platform setup checklist.
+
+## Resources
+
+- GEO research doc
+- `src/routes/sitemap.xml/+server.ts`
+- `src/routes/rss.xml/+server.ts`
+
+## Notes
+
+- Keep sitemap accurate and boring. Decorative priority data is not a priority.

--- a/.plan/specs/instrument-measurement-refresh-and-syndication-loops.md
+++ b/.plan/specs/instrument-measurement-refresh-and-syndication-loops.md
@@ -1,0 +1,102 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+epic: instrument-measurement-refresh-and-syndication-loops
+project: personal-blog
+slug: instrument-measurement-refresh-and-syndication-loops
+status: done
+title: Instrument measurement, refresh, and syndication loops Spec
+type: spec
+updated_at: "2026-04-17T18:10:19Z"
+---
+
+# Instrument measurement, refresh, and syndication loops Spec
+
+Created: 2026-04-17T17:35:50Z
+
+## Why
+
+GEO work needs proof. The site already has partial analytics plumbing, but the current public view signal is not reliable enough to anchor decisions.
+
+## Problem
+
+- Plausible script exists, but post pages can still show `Total Views: 0`.
+- There is no documented KPI set or review cadence in repo planning.
+- Refresh candidate selection is ad hoc.
+- DEV/off-site syndication workflow is not formalized.
+
+## Goals
+
+- Decide whether to fix, replace, or hide the public view counter.
+- Define the KPI baseline and weekly review lens.
+- Create a refresh scoring workflow for old posts.
+- Create a canonical-safe syndication checklist.
+
+## Non-Goals
+
+- Large BI warehouse work on day one.
+- Full automation of referral attribution across every AI assistant.
+- Rewriting all historical posts immediately.
+
+## Constraints
+
+- Plausible is the current analytics surface.
+- Some assistant referrals may be under-attributed by nature.
+- Workflow must work without expensive new tooling.
+
+## Solution Shape
+
+- Verify current Plausible pageview and referrer behavior.
+- Document a small KPI set and review cadence.
+- Add a refresh candidate rubric tied to impressions, CTR, content age, and strategic relevance.
+- Add a publish-then-syndicate checklist with canonical rules and teaser/summary guidance.
+
+## Flows
+
+- Publish or refresh a post.
+- Observe traffic and engagement during defined windows.
+- Decide whether to refresh again, build support content, or syndicate externally.
+- Cross-post only after own-domain publish state is stable.
+
+## Data / Interfaces
+
+- Plausible route/API data
+- Post slug and publish/update dates
+- Refresh cohort list
+- UTM and referral grouping conventions
+
+## Risks / Open Questions
+
+- The views API may be fine while the page load strategy is wrong, or vice versa.
+- Some AI referral traffic may never attribute cleanly.
+- Need decision on whether simple Plausible-only reporting is enough or if docs should leave room for GA4 later.
+
+## Rollout
+
+1. Verify or remove unreliable public metrics.
+2. Define KPI review doc and refresh rubric.
+3. Document syndication process.
+4. Run the loop on the first refresh cohort.
+
+## Verification
+
+- `bun run check`
+- `bun run build`
+- Manual QA of pageview behavior on a representative post.
+- Confirm workflow docs are actionable.
+
+## Story Breakdown
+
+- Story 1: Audit and fix public metrics behavior.
+- Story 2: Add KPI and refresh rubric docs.
+- Story 3: Add syndication workflow and checklist.
+
+## Resources
+
+- `src/routes/+layout.svelte`
+- `src/routes/api/views/[slug]/+server.ts`
+- `src/routes/blog/[slug]/+page.ts`
+- `src/posts/the-ultimate-devto-hacks.md`
+
+## Notes
+
+- If the public view counter stays, it must be trusted. If it cannot be trusted, remove it from the page rather than teaching users to ignore it.

--- a/.plan/specs/normalize-taxonomy-and-launch-topic-hubs.md
+++ b/.plan/specs/normalize-taxonomy-and-launch-topic-hubs.md
@@ -1,0 +1,98 @@
+---
+created_at: "2026-04-17T17:35:50Z"
+epic: normalize-taxonomy-and-launch-topic-hubs
+project: personal-blog
+slug: normalize-taxonomy-and-launch-topic-hubs
+status: done
+title: Normalize taxonomy and launch topic hubs Spec
+type: spec
+updated_at: "2026-04-17T18:10:19Z"
+---
+
+# Normalize taxonomy and launch topic hubs Spec
+
+Created: 2026-04-17T17:35:50Z
+
+## Why
+
+Topic identity is currently fragmented by inconsistent frontmatter and thin archive pages, which makes both human navigation and machine retrieval weaker than it should be.
+
+## Problem
+
+- Raw categories in `src/posts/*.md` contain typos and overlapping concepts.
+- Current category pages are simple filters with almost no explanatory content.
+- There is no central topic model to drive internal links, sitemap inclusion, or hub copy.
+
+## Goals
+
+- Define a canonical topic set.
+- Map existing categories to those topics.
+- Create hub pages with useful intros and related-post groupings.
+- Preserve or redirect legacy category URLs safely.
+
+## Non-Goals
+
+- Full search engine.
+- Automated ML topic discovery.
+- Rewriting every existing post during taxonomy cleanup.
+
+## Constraints
+
+- Existing category URLs may already be indexed.
+- Topic choices should reflect actual post inventory, not aspirational coverage alone.
+- Hub scope needs to stay maintainable for a solo author.
+
+## Solution Shape
+
+- Create a topic map config with canonical slugs, labels, descriptions, and aliases.
+- Normalize post frontmatter toward canonical topic names.
+- Upgrade or replace category pages with richer topic hub routes.
+- Add internal-link rules that point posts back to their hub and to adjacent related posts.
+
+## Flows
+
+- Inventory existing categories.
+- Decide canonical topics and alias mappings.
+- Update post metadata and routing behavior.
+- Launch first hubs and wire them into sitemap and navigation.
+
+## Data / Interfaces
+
+- Frontmatter categories in `src/posts/*.md`
+- Category/topic config module
+- Routes for legacy categories and new topic hubs
+
+## Risks / Open Questions
+
+- Redirect strategy needs care so existing indexed category URLs do not break abruptly.
+- Some categories may be better modeled as series labels than permanent taxonomy.
+
+## Rollout
+
+1. Freeze category inventory and canonical topic proposal.
+2. Add mapping config and route strategy.
+3. Launch first 3 hubs.
+4. Normalize remaining posts in batches.
+
+## Verification
+
+- `bun run check`
+- `bun run build`
+- Spot-check topic pages, category aliases, and internal links.
+
+## Story Breakdown
+
+- Story 1: Build taxonomy inventory and canonical map.
+- Story 2: Implement topic config and route behavior.
+- Story 3: Launch initial hubs and related-post modules.
+- Story 4: Normalize remaining frontmatter categories.
+
+## Resources
+
+- Category inventory from brainstorm session
+- `src/routes/blog/categories/[category]/+page.ts`
+- `src/routes/blog/categories/[category]/+page.svelte`
+
+## Notes
+
+- Start with topics that already have post depth: Bash, Linux, SvelteKit/blogging, self-hosting/security, AI for developers.

--- a/.plan/stories/add-and-document-crawler-policy-surface.md
+++ b/.plan/stories/add-and-document-crawler-policy-surface.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: establish-geo-technical-foundation
+project: personal-blog
+slug: add-and-document-crawler-policy-surface
+spec: establish-geo-technical-foundation
+status: done
+title: Add and document crawler policy surface
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Add and document crawler policy surface
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Add the production crawl policy file and document the bot-access stance so search-facing crawlers remain allowed while training crawlers stay blocked by default.
+
+## Acceptance Criteria
+
+- [ ] A crawl policy file exists for production and states the allowed/disallowed bot policy used by the site.
+
+- [ ] Repo docs explain how the crawler policy should be maintained and why search bots and training bots are treated differently.
+## Verification
+
+- bun run build
+## Resources
+
+- [Canonical Spec](../specs/establish-geo-technical-foundation.md)
+
+- static/robots.txt
+
+- docs/
+## Notes

--- a/.plan/stories/add-external-search-platform-setup-checklist.md
+++ b/.plan/stories/add-external-search-platform-setup-checklist.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: establish-geo-technical-foundation
+project: personal-blog
+slug: add-external-search-platform-setup-checklist
+spec: establish-geo-technical-foundation
+status: done
+title: Add external search platform setup checklist
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Add external search platform setup checklist
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Document the manual setup and verification steps for Google Search Console, Bing Webmaster Tools, and IndexNow so off-repo GEO work is tracked alongside code changes.
+
+## Acceptance Criteria
+
+- [ ] Repo docs include a manual checklist for Search Console, Bing Webmaster Tools, and IndexNow setup or verification.
+
+- [ ] The checklist distinguishes repo work from off-platform validation steps.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/establish-geo-technical-foundation.md)
+
+- docs/
+## Notes

--- a/.plan/stories/add-json-ld-site-and-article-payloads.md
+++ b/.plan/stories/add-json-ld-site-and-article-payloads.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: build-shared-seo-and-structured-data-system
+project: personal-blog
+slug: add-json-ld-site-and-article-payloads
+spec: build-shared-seo-and-structured-data-system
+status: done
+title: Add JSON-LD site and article payloads
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Add JSON-LD site and article payloads
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Add site-level and article-level JSON-LD to the routes that can support it honestly, without inventing unsupported search features or fake structured data targets.
+
+## Acceptance Criteria
+
+- [ ] The site emits honest WebSite or equivalent site-level schema without fake SearchAction markup.
+
+- [ ] Blog post pages emit BlogPosting JSON-LD using post metadata and canonical URLs.
+## Verification
+
+- bun run build
+## Resources
+
+- [Canonical Spec](../specs/build-shared-seo-and-structured-data-system.md)
+
+- src/routes/+page.svelte
+
+- src/routes/blog/[slug]/+page.svelte
+## Notes

--- a/.plan/stories/add-kpi-and-refresh-rubric-docs.md
+++ b/.plan/stories/add-kpi-and-refresh-rubric-docs.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: instrument-measurement-refresh-and-syndication-loops
+project: personal-blog
+slug: add-kpi-and-refresh-rubric-docs
+spec: instrument-measurement-refresh-and-syndication-loops
+status: done
+title: Add KPI and refresh rubric docs
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Add KPI and refresh rubric docs
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Document the weekly KPI lens and refresh-priority rubric so GEO work can be evaluated and sequenced without guessing.
+
+## Acceptance Criteria
+
+- [ ] Repo docs define the small KPI set and weekly review lens for GEO work.
+
+- [ ] The docs include a refresh candidate rubric that can be used to prioritize old posts.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/instrument-measurement-refresh-and-syndication-loops.md)
+
+- docs/
+## Notes

--- a/.plan/stories/add-metadata-to-archive-pages.md
+++ b/.plan/stories/add-metadata-to-archive-pages.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: build-shared-seo-and-structured-data-system
+project: personal-blog
+slug: add-metadata-to-archive-pages
+spec: build-shared-seo-and-structured-data-system
+status: done
+title: Add metadata to archive pages
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Add metadata to archive pages
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Apply the shared metadata helper to the blog index and archive-style pages so each surface exposes route-specific title, description, canonical, and social metadata.
+
+## Acceptance Criteria
+
+- [ ] Blog index and category or topic archive pages emit route-specific title, description, canonical, and social metadata.
+
+- [ ] Archive metadata is generated from shared helper code rather than copy-pasted head blocks.
+## Verification
+
+- bun run check
+## Resources
+
+- [Canonical Spec](../specs/build-shared-seo-and-structured-data-system.md)
+
+- src/routes/blog/+page.svelte
+
+- src/routes/blog/categories/[category]/+page.svelte
+## Notes

--- a/.plan/stories/add-new-post-prompt-and-checklist-pack.md
+++ b/.plan/stories/add-new-post-prompt-and-checklist-pack.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: create-evergreen-content-operations-workflow
+project: personal-blog
+slug: add-new-post-prompt-and-checklist-pack
+spec: create-evergreen-content-operations-workflow
+status: done
+title: Add new-post prompt and checklist pack
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Add new-post prompt and checklist pack
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Add the prompt and checklist assets for net-new posts so future drafting sessions follow the same answer-first, topic-aware publishing standard.
+
+## Acceptance Criteria
+
+- [ ] The repo includes prompt and checklist assets for creating net-new posts with the agreed GEO structure.
+
+- [ ] The pack covers title/meta, source pack use, internal link targets, and publish readiness.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/create-evergreen-content-operations-workflow.md)
+
+- docs/
+## Notes

--- a/.plan/stories/add-refresh-prompt-and-checklist-pack.md
+++ b/.plan/stories/add-refresh-prompt-and-checklist-pack.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: create-evergreen-content-operations-workflow
+project: personal-blog
+slug: add-refresh-prompt-and-checklist-pack
+spec: create-evergreen-content-operations-workflow
+status: done
+title: Add refresh prompt and checklist pack
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Add refresh prompt and checklist pack
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Add the refresh prompt and checklist assets for existing posts so evergreen updates use a consistent audit, rewrite, and verification flow.
+
+## Acceptance Criteria
+
+- [ ] The repo includes a refresh workflow for old posts with audit, rewrite, and verification steps.
+
+- [ ] The pack calls out FAQ, common mistakes, quote-friendly summaries, and updated-date handling.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/create-evergreen-content-operations-workflow.md)
+
+- docs/
+## Notes

--- a/.plan/stories/add-syndication-workflow-and-checklist.md
+++ b/.plan/stories/add-syndication-workflow-and-checklist.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: instrument-measurement-refresh-and-syndication-loops
+project: personal-blog
+slug: add-syndication-workflow-and-checklist
+spec: instrument-measurement-refresh-and-syndication-loops
+status: done
+title: Add syndication workflow and checklist
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Add syndication workflow and checklist
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Document the own-domain-first syndication flow, including when to use full reposts versus summaries and how to keep canonical handling clean.
+
+## Acceptance Criteria
+
+- [ ] Repo docs define an own-domain-first syndication flow with canonical-safe DEV or off-site repost rules.
+
+- [ ] The checklist includes publish timing, teaser or summary guidance, and attribution conventions.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/instrument-measurement-refresh-and-syndication-loops.md)
+
+- docs/
+## Notes

--- a/.plan/stories/audit-and-fix-public-metrics-behavior.md
+++ b/.plan/stories/audit-and-fix-public-metrics-behavior.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: instrument-measurement-refresh-and-syndication-loops
+project: personal-blog
+slug: audit-and-fix-public-metrics-behavior
+spec: instrument-measurement-refresh-and-syndication-loops
+status: done
+title: Audit and fix public metrics behavior
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Audit and fix public metrics behavior
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Decide whether the public post metric should be fixed or removed, then implement the trustworthy behavior and capture the reason in repo docs.
+
+## Acceptance Criteria
+
+- [ ] The public post metrics behavior is either fixed to report real data or intentionally removed when data cannot be trusted.
+
+- [ ] The chosen behavior is documented so future edits do not reintroduce misleading counters.
+## Verification
+
+- bun run check
+## Resources
+
+- [Canonical Spec](../specs/instrument-measurement-refresh-and-syndication-loops.md)
+
+- src/routes/blog/[slug]/+page.ts
+
+- src/routes/api/views/[slug]/+server.ts
+## Notes

--- a/.plan/stories/build-taxonomy-inventory-and-canonical-topic-map.md
+++ b/.plan/stories/build-taxonomy-inventory-and-canonical-topic-map.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: normalize-taxonomy-and-launch-topic-hubs
+project: personal-blog
+slug: build-taxonomy-inventory-and-canonical-topic-map
+spec: normalize-taxonomy-and-launch-topic-hubs
+status: done
+title: Build taxonomy inventory and canonical topic map
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Build taxonomy inventory and canonical topic map
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Define the canonical topic model for the blog, capture alias or typo handling, and align the archive with a topic system that can support hubs and related-post navigation.
+
+## Acceptance Criteria
+
+- [ ] The repo contains a canonical topic inventory with aliases for drifted or misspelled categories.
+
+- [ ] The inventory reflects the current post archive and identifies the initial hub topics to support.
+## Verification
+
+- manual taxonomy review
+## Resources
+
+- [Canonical Spec](../specs/normalize-taxonomy-and-launch-topic-hubs.md)
+
+- src/posts/*.md
+
+- src/lib/
+## Notes

--- a/.plan/stories/create-shared-seo-metadata-helper.md
+++ b/.plan/stories/create-shared-seo-metadata-helper.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: build-shared-seo-and-structured-data-system
+project: personal-blog
+slug: create-shared-seo-metadata-helper
+spec: build-shared-seo-and-structured-data-system
+status: done
+title: Create shared SEO metadata helper
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Create shared SEO metadata helper
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Create a shared metadata helper under `src/lib` so canonical URLs, social metadata, and page-level defaults are generated from typed inputs instead of duplicated route logic.
+
+## Acceptance Criteria
+
+- [ ] A shared metadata helper exists under src/lib and can derive canonical, social, and route metadata from typed inputs.
+
+- [ ] Home, blog, and post routes have a path to use the shared helper instead of duplicating values by hand.
+## Verification
+
+- bun run check
+## Resources
+
+- [Canonical Spec](../specs/build-shared-seo-and-structured-data-system.md)
+
+- src/lib/
+
+- src/lib/config.ts
+## Notes

--- a/.plan/stories/expand-sitemap-coverage-and-stable-url-sources.md
+++ b/.plan/stories/expand-sitemap-coverage-and-stable-url-sources.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: establish-geo-technical-foundation
+project: personal-blog
+slug: expand-sitemap-coverage-and-stable-url-sources
+spec: establish-geo-technical-foundation
+status: done
+title: Expand sitemap coverage and stable URL sources
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Expand sitemap coverage and stable URL sources
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Refactor sitemap generation to include stable site routes beyond posts and source those URLs from reusable code paths that can grow with topic hubs and taxonomy changes.
+
+## Acceptance Criteria
+
+- [ ] The sitemap includes stable core routes in addition to canonical post URLs.
+
+- [ ] Sitemap generation uses deterministic route sources that can grow with topic or category pages.
+## Verification
+
+- bun run build
+## Resources
+
+- [Canonical Spec](../specs/establish-geo-technical-foundation.md)
+
+- src/routes/sitemap.xml/+server.ts
+
+- src/routes/api/posts/+server.ts
+## Notes

--- a/.plan/stories/implement-topic-config-and-route-behavior.md
+++ b/.plan/stories/implement-topic-config-and-route-behavior.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: normalize-taxonomy-and-launch-topic-hubs
+project: personal-blog
+slug: implement-topic-config-and-route-behavior
+spec: normalize-taxonomy-and-launch-topic-hubs
+status: done
+title: Implement topic config and route behavior
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Implement topic config and route behavior
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Implement the reusable topic configuration and route behavior needed to serve canonical topic pages while keeping legacy category archives and redirects working.
+
+## Acceptance Criteria
+
+- [ ] Route logic can resolve a canonical topic and any supported aliases to the same topic content.
+
+- [ ] The topic routing behavior is driven by config instead of hard-coded per-page branching.
+## Verification
+
+- bun run check
+## Resources
+
+- [Canonical Spec](../specs/normalize-taxonomy-and-launch-topic-hubs.md)
+
+- src/routes/blog/categories/[category]/+page.ts
+
+- src/lib/
+## Notes

--- a/.plan/stories/launch-initial-hubs-and-related-post-modules.md
+++ b/.plan/stories/launch-initial-hubs-and-related-post-modules.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: normalize-taxonomy-and-launch-topic-hubs
+project: personal-blog
+slug: launch-initial-hubs-and-related-post-modules
+spec: normalize-taxonomy-and-launch-topic-hubs
+status: done
+title: Launch initial hubs and related-post modules
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Launch initial hubs and related-post modules
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Launch the first topic hubs and connect posts back into those hubs with topic-aware navigation and related-post surfaces.
+
+## Acceptance Criteria
+
+- [ ] Initial topic pages render explanatory hub content instead of only a bare filtered post list.
+
+- [ ] Post pages surface related-post or hub navigation modules tied to the canonical topic map.
+## Verification
+
+- bun run build
+## Resources
+
+- [Canonical Spec](../specs/normalize-taxonomy-and-launch-topic-hubs.md)
+
+- src/routes/blog/categories/[category]/+page.svelte
+
+- src/routes/blog/[slug]/+page.svelte
+## Notes

--- a/.plan/stories/migrate-post-route-and-fix-canonical-bug.md
+++ b/.plan/stories/migrate-post-route-and-fix-canonical-bug.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: build-shared-seo-and-structured-data-system
+project: personal-blog
+slug: migrate-post-route-and-fix-canonical-bug
+spec: build-shared-seo-and-structured-data-system
+status: done
+title: Migrate post route and fix canonical bug
+type: story
+updated_at: "2026-04-17T18:02:37Z"
+---
+
+# Migrate post route and fix canonical bug
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Move the post route onto the shared metadata helper and replace the broken canonical and social URL output with the correct slug-derived page URL.
+
+## Acceptance Criteria
+
+- [ ] The blog post page emits the correct canonical URL and social URL for the current slug.
+
+- [ ] The post route uses the shared metadata helper instead of duplicating URL logic inline.
+## Verification
+
+- bun run check
+## Resources
+
+- [Canonical Spec](../specs/build-shared-seo-and-structured-data-system.md)
+
+- src/routes/blog/[slug]/+page.svelte
+## Notes

--- a/.plan/stories/normalize-remaining-frontmatter-categories.md
+++ b/.plan/stories/normalize-remaining-frontmatter-categories.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: normalize-taxonomy-and-launch-topic-hubs
+project: personal-blog
+slug: normalize-remaining-frontmatter-categories
+spec: normalize-taxonomy-and-launch-topic-hubs
+status: done
+title: Normalize remaining frontmatter categories
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Normalize remaining frontmatter categories
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Clean up obvious category drift and frontmatter inconsistency so the archive no longer exposes typo slugs or mismatched taxonomy metadata.
+
+## Acceptance Criteria
+
+- [ ] Legacy typo and drift categories in post frontmatter are normalized to the canonical topic model or explicit aliases.
+
+- [ ] The normalized category set no longer contains obvious misspellings or duplicate concepts.
+## Verification
+
+- manual frontmatter review
+## Resources
+
+- [Canonical Spec](../specs/normalize-taxonomy-and-launch-topic-hubs.md)
+
+- src/posts/*.md
+## Notes

--- a/.plan/stories/test-workflow-on-first-refresh-cohort.md
+++ b/.plan/stories/test-workflow-on-first-refresh-cohort.md
@@ -1,0 +1,36 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: create-evergreen-content-operations-workflow
+project: personal-blog
+slug: test-workflow-on-first-refresh-cohort
+spec: create-evergreen-content-operations-workflow
+status: done
+title: Test workflow on first refresh cohort
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Test workflow on first refresh cohort
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Run the new refresh workflow against the first candidate post and use the result to prove the docs and prompts are specific enough for real content work.
+
+## Acceptance Criteria
+
+- [ ] At least one existing post is updated using the new refresh workflow and the result is captured in repo docs or content.
+
+- [ ] The dry run identifies any workflow friction that should be corrected in the docs.
+## Verification
+
+- manual before-after review
+## Resources
+
+- [Canonical Spec](../specs/create-evergreen-content-operations-workflow.md)
+
+- src/posts/
+
+- docs/
+## Notes

--- a/.plan/stories/write-content-operations-guide.md
+++ b/.plan/stories/write-content-operations-guide.md
@@ -1,0 +1,34 @@
+---
+created_at: "2026-04-17T17:57:01Z"
+epic: create-evergreen-content-operations-workflow
+project: personal-blog
+slug: write-content-operations-guide
+spec: create-evergreen-content-operations-workflow
+status: done
+title: Write content operations guide
+type: story
+updated_at: "2026-04-17T18:09:58Z"
+---
+
+# Write content operations guide
+
+Created: 2026-04-17T17:57:01Z
+
+## Description
+
+Write the durable publishing and refresh workflow doc that explains how a new article or evergreen update should move from idea to live page on the site.
+
+## Acceptance Criteria
+
+- [ ] Repo docs define a repeatable flow for drafting, reviewing, publishing, and refreshing content.
+
+- [ ] The guide explains source packs, answer-first intros, internal links, and verification gates.
+## Verification
+
+- manual doc review
+## Resources
+
+- [Canonical Spec](../specs/create-evergreen-content-operations-workflow.md)
+
+- docs/
+## Notes

--- a/docs/content-operations.md
+++ b/docs/content-operations.md
@@ -1,0 +1,109 @@
+# Content Operations
+
+## Goal
+
+Turn publishing on `jimmymcbride.dev` into a repeatable system instead of a one-off writing sprint.
+
+The operating standard:
+
+- own-domain first
+- answer-first structure
+- source-backed claims
+- explicit internal links
+- topic-aware publishing
+- scheduled refreshes for evergreen posts
+
+## Frontmatter Contract
+
+Every published post should include:
+
+```yaml
+title:
+description:
+short:
+date:
+updated:
+image:
+categories:
+topics:
+published: true
+```
+
+### Field Rules
+
+- `description`: detailed summary for archive cards and long-form metadata.
+- `short`: tighter summary for search and social reuse when the full description is too long.
+- `categories`: tag/archive metadata. These can describe content type, subtopic, or series.
+- `topics`: canonical hub mapping. Use these to connect the post to `/topics/*`.
+- `updated`: change this whenever a meaningful refresh ships.
+
+## New Post Workflow
+
+1. Pick one canonical topic first.
+2. Build a source pack before drafting.
+3. Define the primary query or question the post should answer.
+4. Draft the answer-first intro before writing the full body.
+5. Add internal links while drafting, not at the end.
+6. Verify metadata, topic assignment, and publish surface before shipping.
+7. Publish on your domain first.
+8. Syndicate only after the own-domain page is live and checked.
+
+## Refresh Workflow
+
+1. Pick the page and state why it deserves a refresh.
+2. Audit the current intro, structure, links, and metadata.
+3. Rebuild the source pack if technical claims may have changed.
+4. Rewrite the opening so the answer appears immediately.
+5. Add or improve FAQ, common mistakes, and next-step guidance.
+6. Update internal links to current hubs and relevant posts.
+7. Update `short`, `updated`, categories, and topics if needed.
+8. Re-check metadata and rendered output after publish.
+
+## Required Review Gates
+
+### Intent gate
+
+- What exact reader question should this page answer?
+- Which topic hub should the page strengthen?
+
+### Source gate
+
+- Which claims require a source?
+- Which claims come from first-hand experience and should be framed that way?
+
+### Structure gate
+
+- Does the answer appear in the first two sentences?
+- Can a reader scan headings and understand the page promise?
+
+### Technical gate
+
+- Does the page have `short`, `updated`, and the right topic?
+- Are internal links pointing at current URLs?
+
+### Measurement gate
+
+- What would make this refresh worth keeping?
+- Should the page be watched for CTR, impressions, or referral traffic?
+
+## Internal Linking Rules
+
+- Link every post to at least one canonical topic hub.
+- Add at least two related-post links that move the reader forward.
+- Prefer links that deepen the same topic cluster before branching sideways.
+- Replace stale links during refreshes, even if the body copy barely changes.
+
+## Content Structure Baseline
+
+For evergreen technical posts, default to:
+
+1. Direct answer
+2. Who this is for
+3. Prerequisites
+4. What the reader will learn
+5. Main walkthrough
+6. Common mistakes
+7. FAQ
+8. Next steps / related reading
+
+Not every post needs every section, but every post should justify what it leaves out.

--- a/docs/content-prompts.md
+++ b/docs/content-prompts.md
@@ -1,0 +1,102 @@
+# Content Prompt Packs
+
+These prompts are for structuring work, not replacing judgment. Every prompt assumes you already have a source pack and target topic.
+
+## New Post Prompt
+
+```text
+You are helping draft a technical article for jimmymcbride.dev.
+
+Topic:
+- {{topic}}
+
+Canonical hub:
+- {{topic_hub}}
+
+Target reader:
+- {{reader}}
+
+Target query:
+- {{target_query}}
+
+Source pack:
+- {{source_pack}}
+
+Internal link targets:
+- {{internal_links}}
+
+Requirements:
+- Answer the target query in the first 2 sentences.
+- Preserve Jimmy's direct, first-hand voice.
+- If a claim is uncertain, write [verification needed].
+- Add a clear "who this is for" section.
+- Add prerequisites when the tutorial assumes baseline knowledge.
+- Suggest 2 to 4 internal links from the provided targets.
+- End with common mistakes, FAQ, and next steps.
+- Output title options, short summary, full outline, and draft.
+```
+
+## New Post Checklist
+
+- Primary topic chosen
+- Source pack attached
+- Answer-first intro present
+- `short` summary written
+- Internal links added
+- FAQ and next steps included when relevant
+- Frontmatter includes `topics` and `updated`
+
+## Refresh Prompt
+
+```text
+You are refreshing an existing article for jimmymcbride.dev.
+
+Post:
+- {{post_path}}
+
+Canonical hub:
+- {{topic_hub}}
+
+Current target query:
+- {{target_query}}
+
+Source pack:
+- {{source_pack}}
+
+Internal link targets:
+- {{internal_links}}
+
+Tasks:
+- Rewrite the opening so the answer lands immediately.
+- Keep Jimmy's voice and first-hand positioning.
+- Add or improve FAQ and common mistakes sections.
+- Add stronger next-step links to current topic hubs or related posts.
+- Flag weak claims with [source needed].
+- Return a short before/after summary before the revised draft.
+```
+
+## Refresh Checklist
+
+- Opening rewritten for direct answer
+- Metadata reviewed
+- `updated` changed
+- Topic hub link added or corrected
+- FAQ reviewed
+- Common mistakes reviewed
+- Next-step links reviewed
+- Search/social summary (`short`) reviewed
+
+## Title and Meta Prompt
+
+```text
+Using the final draft, generate:
+- 6 title options under 60 characters
+- 4 meta descriptions under 155 characters
+- 1 short summary for the `short` frontmatter field
+
+Constraints:
+- No clickbait
+- Use strong verbs
+- Avoid repeating stale title patterns already used on the site
+- Prefer clarity over hype
+```

--- a/docs/geo-measurement.md
+++ b/docs/geo-measurement.md
@@ -1,0 +1,69 @@
+# GEO Measurement and Refresh Loop
+
+## Public Metrics Decision
+
+The post-level `Total Views` counter was removed from the public UI.
+
+Reason:
+
+- The site is prerendered.
+- The old counter depended on a client fetch after render.
+- The prerendered shell exposed a misleading `0` state before hydration and made the metric look broken.
+
+Keep Plausible and the views API for internal analysis, but do not show a public metric unless it is trustworthy in the rendered experience.
+
+## Weekly KPI Set
+
+- Non-brand impressions by landing page
+- Organic clicks by landing page
+- CTR by refreshed page
+- Topic hub entry traffic
+- Sessions from assistant or referral sources when attributable
+- Newsletter or subscriber conversion from content pages
+
+## Review Lens
+
+Check these every week:
+
+1. Which refreshed pages gained impressions?
+2. Which pages gained impressions but still miss clicks?
+3. Which topic hubs are pulling readers deeper into the archive?
+4. Which posts deserve another refresh instead of a new article?
+
+## Refresh Rubric
+
+Score each candidate from 1 to 5 in these buckets:
+
+- Search upside
+  - high impressions, weak CTR, or clear query mismatch
+- Strategic fit
+  - strengthens a current topic hub or supports current publishing direction
+- Refresh cost
+  - easy structural win versus full rewrite
+- Link opportunity
+  - can connect to stronger hubs or newer supporting posts
+- Freshness risk
+  - tools, frameworks, or advice have drifted since publish
+
+### Prioritization Rule
+
+- Refresh first when total score is high and rewrite cost is moderate.
+- Publish new only when the existing cluster is already structurally healthy.
+
+## First Refresh Cohort
+
+Start with:
+
+- `src/posts/cat-grep-and-go.md`
+- `src/posts/sveltekit-blog.md`
+- `src/posts/self-host-your-digital-empire.md`
+- `src/posts/the-ultimate-devto-hacks.md`
+
+## What a Good Refresh Should Change
+
+- better opening
+- current metadata
+- stronger topic alignment
+- better internal links
+- FAQ or common mistakes where helpful
+- current `updated` date

--- a/docs/geo-technical-foundation.md
+++ b/docs/geo-technical-foundation.md
@@ -1,0 +1,51 @@
+# GEO Technical Foundation
+
+## Crawler Policy
+
+The site now uses `static/robots.txt` as the crawl policy surface.
+
+- Allow general search crawling.
+- Allow search-facing AI crawlers that can generate discovery or referral traffic.
+- Block training crawlers by default.
+- Keep internal-only paths out of crawl.
+
+This split matches the current GEO goal: maximize citation and discovery surfaces without opting into training access by default.
+
+### Maintenance Rules
+
+- Update `static/robots.txt` whenever crawler policy changes.
+- Keep the sitemap URL in `robots.txt` aligned with production.
+- Do not add `llms.txt` or `SearchAction` just because they sound GEO-related. Only add them when the site supports the behavior honestly.
+
+## Manual Search Platform Checklist
+
+These steps are outside the repo but belong to the GEO operating loop.
+
+### Google Search Console
+
+1. Verify the domain property for `jimmymcbride.dev`.
+2. Submit `https://jimmymcbride.dev/sitemap.xml`.
+3. Inspect `/`, `/blog`, and a sample of refreshed post URLs.
+4. Confirm the selected canonical matches the intended page URL.
+5. Review indexing, coverage, and Core Web Vitals after significant site changes.
+
+### Bing Webmaster Tools
+
+1. Verify the site property.
+2. Submit the sitemap.
+3. Check crawl and indexing coverage for core routes and refreshed posts.
+4. Confirm any IndexNow submission path is accepted once implemented.
+
+### IndexNow
+
+1. Create and store the key material securely.
+2. Decide whether submissions happen manually or via a publish hook.
+3. Submit changed URLs after major refreshes or new topic hubs ship.
+4. Confirm successful submission in Bing tooling or logs.
+
+## Validation Checklist
+
+- `robots.txt` renders in production.
+- `sitemap.xml` renders in production.
+- Sitemap contains the intended canonical URLs only.
+- Search Console and Bing both show the sitemap as readable.

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -1,7 +1,6 @@
 ---
-updated: "2026-04-16T15:16:14Z"
+updated: "2026-04-17T18:10:51Z"
 ---
-
 # Project Architecture
 
 <!-- brain:begin project-doc-architecture -->
@@ -16,6 +15,10 @@ Use this file for the structural shape of the repository.
 
 ## Local Notes
 
+- GEO metadata is now centralized in `src/lib/seo.ts`, which supplies canonical, social, and JSON-LD data to home, archive, post, and topic routes.
+- Canonical content subjects now live in `topics` frontmatter plus `src/lib/taxonomy.ts`; `categories` remain tag/archive metadata and legacy typo slugs redirect to normalized category URLs.
+- Topic hubs now live under `/topics` with prerendered topic pages and post-to-topic navigation. Keep sitemap generation aligned with `src/lib/taxonomy.ts` as topics evolve.
+- The public post view counter was intentionally removed from `src/routes/blog/[slug]/+page.svelte` because the prerendered zero-state was misleading. Keep Plausible or the views API for internal reporting unless a trustworthy hydrated counter is reintroduced.
 - Blog post markdown renders inside the `.markdown` container in `src/routes/blog/[slug]/+page.svelte`, which uses a centered flex column.
 - Keep explicit `width: 100%` rules for markdown list containers in `src/app.css` alongside headings, paragraphs, and code blocks, or unordered and ordered lists will shrink and appear centered.
 - Tailwind v4 theme setup in `src/app.css` must keep the semantic token bridge (`@theme inline` mappings like `--color-card`, `--color-background`, `--color-border`, and related radius tokens) so shadcn-style component classes such as `bg-card`, `border-border`, and `text-muted-foreground` compile correctly.

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -1,3 +1,6 @@
+---
+updated: "2026-04-17T17:39:07Z"
+---
 # Project Workflows
 
 <!-- brain:begin project-doc-workflows -->
@@ -42,6 +45,7 @@ Use this file for agent operating workflow inside the repo.
 
 ## Local Notes
 
+- `.plan/` is now the repo-local planning workspace. Use it for brainstorms, epics, specs, stories, and roadmap work such as GEO planning before implementation starts.
 Add repo-specific notes here. `brain context refresh` preserves content outside managed blocks.
 
 - Bun is the default tool for installs, scripts, and one-off CLIs in this repo. Prefer `bun install`, `bun run <script>`, and `bunx <tool>` in examples and operational guidance.

--- a/docs/syndication-workflow.md
+++ b/docs/syndication-workflow.md
@@ -1,0 +1,47 @@
+# Syndication Workflow
+
+## Rule
+
+Publish on `jimmymcbride.dev` first. Syndicate later.
+
+The own-domain page is the canonical version. Off-site versions exist to widen discovery, not to replace your site.
+
+## Default Flow
+
+1. Publish the article on `jimmymcbride.dev`.
+2. Verify the page metadata, canonical, and topic links.
+3. Wait until the page is stable enough to promote.
+4. Choose one syndication mode:
+   - full canonical repost
+   - summary / teaser repost
+5. Add UTMs when you control the outbound link.
+6. Record which channels were used so the refresh loop can compare results later.
+
+## DEV Checklist
+
+- Own-domain article is live first
+- DEV canonical points to the own-domain article when reposting full content
+- If not reposting full content, use a summary that links back to the original
+- Do not publish conflicting titles or intros that compete with the canonical page
+- Link the relevant topic hub when it helps the reader keep exploring
+
+## Summary Post Pattern
+
+Use a summary post when:
+
+- the original article is long
+- the original article already ranks well
+- you want off-site comments without duplicating the full body
+
+Recommended summary shape:
+
+1. strong hook
+2. short context
+3. one or two key takeaways
+4. link back to the original article
+
+## Attribution Rules
+
+- Do not present an off-site rewrite as the primary source.
+- Keep titles aligned enough that readers recognize the original article.
+- Use consistent language around the original article being the full version.

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -12,9 +12,12 @@ interface Post {
 	title: string
 	slug: string
 	description: string
+	short?: string
 	image?: string
 	date: string
+	updated?: string
 	categories: string[]
+	topics?: string[]
 	published: boolean
 }
 

--- a/src/lib/components/BlogCard.svelte
+++ b/src/lib/components/BlogCard.svelte
@@ -1,35 +1,82 @@
 <script lang="ts">
 	import { formatDate } from "$lib/utils.js"
 
-	let { post } = $props()
+	let {
+		post,
+		variant = "default",
+	}: {
+		post: Post
+		variant?: "default" | "compact"
+	} = $props()
+
+	let displayDate = $derived(post.updated ?? post.date)
 </script>
 
 {#key post.slug}
-	<a
-		class="rounded-lg bg-card text-card-foreground overflow-hidden w-full max-w-4xl mt-4 mx-4 transition-colors hover:bg-accent border border-border"
-		href={`/blog/${post.slug}`}
-	>
-		<header class="mb-4">
-			{#if post.image}
-				<img src={post.image} alt="" width="1000px" loading="lazy" />
-			{/if}
-		</header>
+	{#if variant === "compact"}
+		<a
+			class="group mt-4 block w-full max-w-4xl overflow-hidden rounded-[1.5rem] border border-border/80 bg-card/90 text-card-foreground transition-colors hover:border-primary/35 hover:bg-accent/20"
+			href={`/blog/${post.slug}`}
+		>
+			<div class="grid gap-5 p-5 md:grid-cols-[minmax(0,1fr)_13rem] md:items-start">
+				<div class="space-y-3">
+					<h3 class="text-xl font-bold leading-tight sm:text-2xl" data-toc-ignore>{post.title}</h3>
+					<p class="text-sm leading-7 text-muted-foreground sm:text-base">
+						{post.short ?? post.description}
+					</p>
+				</div>
 
-		<div class="p-4 space-y-4">
-			<h3 class="text-2xl font-bold" data-toc-ignore>{post.title}</h3>
-			<article>
-				<p>
-					{post.description}
-				</p>
-			</article>
-		</div>
-		<hr class="opacity-50" />
-		<footer class="p-4 flex justify-start items-center space-x-4">
-			<img src="/me-anime.webp" alt="Jimmy McBride" class="w-8 h-8 rounded-full" loading="lazy" />
-			<div class="flex-auto flex justify-between items-center">
-				<h6 class="font-bold" data-toc-ignore>By Jimmy McBride</h6>
-				<small>On {formatDate(post.date)}</small>
+				{#if post.image}
+					<div class="overflow-hidden rounded-2xl border border-border/70 bg-muted">
+						<img
+							src={post.image}
+							alt=""
+							class="h-40 w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+							width="1000"
+							loading="lazy"
+						/>
+					</div>
+				{/if}
 			</div>
-		</footer>
-	</a>
+
+			<div class="border-t border-border/70 px-5 py-4">
+				<div class="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+					<img src="/me-anime.webp" alt="Jimmy McBride" class="h-8 w-8 rounded-full" loading="lazy" />
+					<div class="flex flex-wrap items-center gap-2">
+						<span class="font-semibold text-foreground" data-toc-ignore>Jimmy McBride</span>
+						<span class="hidden sm:inline">/</span>
+						<span>{post.updated ? "Updated" : "Published"} {formatDate(displayDate)}</span>
+					</div>
+				</div>
+			</div>
+		</a>
+	{:else}
+		<a
+			class="rounded-lg bg-card text-card-foreground overflow-hidden w-full max-w-4xl mt-4 mx-4 transition-colors hover:bg-accent border border-border"
+			href={`/blog/${post.slug}`}
+		>
+			<header class="mb-4">
+				{#if post.image}
+					<img src={post.image} alt="" width="1000px" loading="lazy" />
+				{/if}
+			</header>
+
+			<div class="p-4 space-y-4">
+				<h3 class="text-2xl font-bold" data-toc-ignore>{post.title}</h3>
+				<article>
+					<p>
+						{post.description}
+					</p>
+				</article>
+			</div>
+			<hr class="opacity-50" />
+			<footer class="p-4 flex justify-start items-center space-x-4">
+				<img src="/me-anime.webp" alt="Jimmy McBride" class="w-8 h-8 rounded-full" loading="lazy" />
+				<div class="flex-auto flex justify-between items-center">
+					<h6 class="font-bold" data-toc-ignore>By Jimmy McBride</h6>
+					<small>On {formatDate(post.date)}</small>
+				</div>
+			</footer>
+		</a>
+	{/if}
 {/key}

--- a/src/lib/components/archive/ArchiveSearchInput.svelte
+++ b/src/lib/components/archive/ArchiveSearchInput.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { buttonVariants } from "$lib/components/ui/button"
+	import { cn } from "$lib/utils.js"
+
+	let {
+		id,
+		label,
+		placeholder,
+		value,
+		resultsLabel,
+		pageLabel = "",
+		onValueChange,
+		onClear,
+	}: {
+		id: string
+		label: string
+		placeholder: string
+		value: string
+		resultsLabel: string
+		pageLabel?: string
+		onValueChange?: (value: string) => void
+		onClear?: () => void
+	} = $props()
+
+	function handleInput(event: Event) {
+		const target = event.currentTarget as HTMLInputElement
+		onValueChange?.(target.value)
+	}
+</script>
+
+<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+	<div class="w-full max-w-xl">
+		<label class="sr-only" for={id}>{label}</label>
+		<div class="relative">
+			<input
+				id={id}
+				type="search"
+				name="search"
+				autocomplete="off"
+				value={value}
+				placeholder={placeholder}
+				class="flex h-11 w-full rounded-full border border-input bg-background px-4 pr-20 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				oninput={handleInput}
+			/>
+			{#if value.trim()}
+				<button
+					type="button"
+					class={cn(
+						buttonVariants("ghost", "sm"),
+						"absolute right-1 top-1/2 h-8 -translate-y-1/2 rounded-full px-3 text-xs"
+					)}
+					aria-label={`Clear ${label.toLowerCase()}`}
+					onclick={() => onClear?.()}
+				>
+					Clear
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<div class="flex flex-col items-start gap-1 text-sm text-muted-foreground lg:items-end">
+		<p>{resultsLabel}</p>
+		{#if pageLabel}
+			<p class="font-mono text-xs uppercase tracking-[0.2em]">{pageLabel}</p>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/archive/PaginationNav.svelte
+++ b/src/lib/components/archive/PaginationNav.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { Button, buttonVariants } from "$lib/components/ui/button"
+	import { cn } from "$lib/utils.js"
+
+	let {
+		currentPage,
+		totalPages,
+		onPageChange,
+	}: {
+		currentPage: number
+		totalPages: number
+		onPageChange?: (page: number) => void
+	} = $props()
+
+	let pageNumbers = $derived(Array.from({ length: totalPages }, (_, index) => index + 1))
+</script>
+
+{#if totalPages > 1}
+	<nav
+		class="mt-8 flex flex-wrap items-center justify-center gap-2"
+		aria-label="Topic archive pagination"
+	>
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			disabled={currentPage === 1}
+			aria-label="Previous page"
+			onclick={() => onPageChange?.(currentPage - 1)}
+		>
+			Previous
+		</Button>
+
+		{#each pageNumbers as pageNumber}
+			<button
+				type="button"
+				class={cn(
+					buttonVariants(pageNumber === currentPage ? "default" : "outline", "sm"),
+					"min-w-9 rounded-full px-3"
+				)}
+				aria-current={pageNumber === currentPage ? "page" : undefined}
+				aria-label={`Go to page ${pageNumber}`}
+				onclick={() => onPageChange?.(pageNumber)}
+			>
+				{pageNumber}
+			</button>
+		{/each}
+
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			disabled={currentPage === totalPages}
+			aria-label="Next page"
+			onclick={() => onPageChange?.(currentPage + 1)}
+		>
+			Next
+		</Button>
+	</nav>
+{/if}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,3 +4,5 @@ export const title = "Jimmy McBride"
 export const description =
 	"Fullstack Wizard ✨ Crafting cutting-edge apps 🚀 Passionate about UI/UX design 🎨 Forever learning & evolving 🌱"
 export const url = dev ? "http://localhost:5173" : "https://jimmymcbride.dev"
+export const authorName = "Jimmy McBride"
+export const twitterHandle = "@McBride1105"

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,36 @@
+function sortPostsByDate(posts: Post[]) {
+	return posts.sort(
+		(first, second) => new Date(second.date).getTime() - new Date(first.date).getTime()
+	)
+}
+
+export function getPublishedPosts() {
+	const posts: Post[] = []
+	const paths = import.meta.glob("/src/posts/*.md", { eager: true })
+
+	for (const path in paths) {
+		const file = paths[path]
+		const slug = path.split("/").at(-1)?.replace(".md", "")
+
+		if (file && typeof file === "object" && "metadata" in file && slug) {
+			const metadata = file.metadata as Omit<Post, "slug">
+			const post = { ...metadata, slug } satisfies Post
+
+			if (post.published) {
+				posts.push(post)
+			}
+		}
+	}
+
+	return sortPostsByDate(posts)
+}
+
+export function getUniqueCategories(posts = getPublishedPosts()) {
+	return [...new Set(posts.flatMap((post) => post.categories))].sort((first, second) =>
+		first.localeCompare(second)
+	)
+}
+
+export function getMostRecentPostDate(posts = getPublishedPosts()) {
+	return posts[0]?.updated ?? posts[0]?.date ?? new Date().toISOString().slice(0, 10)
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,118 @@
+import { authorName, description as defaultDescription, title as defaultTitle, url } from "$lib/config"
+import { formatTaxonomyLabel } from "$lib/taxonomy"
+
+type SeoPageType = "website" | "article"
+
+interface SeoInput {
+	path: string
+	title: string
+	description: string
+	image?: string
+	type?: SeoPageType
+	publishedTime?: string
+	modifiedTime?: string
+}
+
+function toIsoDate(date?: string) {
+	if (!date) return undefined
+
+	const parsedDate = new Date(date.replaceAll("-", "/"))
+
+	if (Number.isNaN(parsedDate.getTime())) {
+		return undefined
+	}
+
+	return parsedDate.toISOString()
+}
+
+export function toAbsoluteUrl(path: string) {
+	return new URL(path, url).toString()
+}
+
+export function toAbsoluteImageUrl(image = "/blog-banner.webp") {
+	if (image.startsWith("http://") || image.startsWith("https://")) {
+		return image
+	}
+
+	return toAbsoluteUrl(image)
+}
+
+export function formatCategoryLabel(category: string) {
+	return formatTaxonomyLabel(category)
+}
+
+export function createSeo({
+	path,
+	title,
+	description,
+	image,
+	type = "website",
+	publishedTime,
+	modifiedTime,
+}: SeoInput) {
+	const canonical = toAbsoluteUrl(path)
+	const resolvedImage = toAbsoluteImageUrl(image)
+
+	return {
+		title,
+		description,
+		canonical,
+		image: resolvedImage,
+		type,
+		publishedTime: toIsoDate(publishedTime),
+		modifiedTime: toIsoDate(modifiedTime),
+		twitterCard: "summary_large_image",
+	}
+}
+
+export function createWebsiteJsonLd() {
+	return {
+		"@context": "https://schema.org",
+		"@type": "WebSite",
+		"@id": `${url}/#website`,
+		url,
+		name: defaultTitle,
+		description: defaultDescription,
+		inLanguage: "en-US",
+	}
+}
+
+export function createBlogPostingJsonLd(post: Post) {
+	return {
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		"@id": `${toAbsoluteUrl(`/blog/${post.slug}`)}#article`,
+		mainEntityOfPage: toAbsoluteUrl(`/blog/${post.slug}`),
+		headline: post.title,
+		description: post.short ?? post.description,
+		image: [toAbsoluteImageUrl(post.image)],
+		datePublished: toIsoDate(post.date),
+		dateModified: toIsoDate(post.updated ?? post.date),
+		author: {
+			"@type": "Person",
+			name: authorName,
+			url,
+		},
+		publisher: {
+			"@type": "Person",
+			name: authorName,
+			url,
+		},
+		inLanguage: "en-US",
+		isAccessibleForFree: true,
+		articleSection: post.categories[0],
+		keywords: post.categories,
+		about: post.categories.map((category) => ({
+			"@type": "Thing",
+			name: formatCategoryLabel(category),
+		})),
+	}
+}
+
+export function renderJsonLd(data: unknown) {
+	return JSON.stringify(data).replace(/</g, "\\u003c")
+}
+
+export function renderJsonLdScript(data: unknown) {
+	return `<script type="application/ld+json">${renderJsonLd(data)}</script>`
+}

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -1,0 +1,126 @@
+export interface TopicDefinition {
+	slug: string
+	title: string
+	description: string
+	summary: string
+	focusAreas: string[]
+}
+
+export const categoryAliases: Record<string, string> = {
+	"careerdevelopment": "career-development",
+	"texutal-healing": "textual-healing",
+	"tutoiral": "tutorial",
+}
+
+const topics: TopicDefinition[] = [
+	{
+		slug: "bash",
+		title: "Bash and Shell Automation",
+		description:
+			"Command-line tutorials, shell workflows, text-processing tools, and practical Bash automation for everyday developer work.",
+		summary:
+			"Learn the shell through real commands, scripts, and text-manipulation workflows that make terminal work faster and more useful.",
+		focusAreas: ["Shell basics", "Text processing", "Bash scripting", "Git automation"],
+	},
+	{
+		slug: "linux",
+		title: "Linux and Systems",
+		description:
+			"Linux setup, Arch installation, systems thinking, and practical guidance for working comfortably on developer machines.",
+		summary:
+			"Explore Linux from both the practical and opinionated sides, from installation guides to day-to-day systems work.",
+		focusAreas: ["Arch Linux", "System setup", "Developer workflow", "Open systems"],
+	},
+	{
+		slug: "sveltekit-blogging",
+		title: "SvelteKit and Web Publishing",
+		description:
+			"Posts about building developer blogs, shipping content sites, and improving publishing infrastructure with SvelteKit and search fundamentals.",
+		summary:
+			"Follow the architectural side of running a technical blog, from SvelteKit implementation to publishing and SEO mechanics.",
+		focusAreas: ["SvelteKit", "Blog architecture", "Publishing workflow", "SEO basics"],
+	},
+	{
+		slug: "self-hosting",
+		title: "Self-Hosting and Security",
+		description:
+			"Open-source hosting, operations, analytics ownership, and the security lessons that come with running your own stack.",
+		summary:
+			"Learn from first-hand self-hosting decisions, platform choices, and security failures that turned into durable operating rules.",
+		focusAreas: ["Coolify", "Plausible", "Firewalls", "Operational tradeoffs"],
+	},
+	{
+		slug: "ai",
+		title: "AI for Developers",
+		description:
+			"Practical writing, coding, and tooling workflows for using AI without flattening judgment, authenticity, or source quality.",
+		summary:
+			"Use AI as a tool, not a replacement, with patterns grounded in real developer and creator workflows.",
+		focusAreas: ["AI writing workflows", "AI coding", "Open-source AI tooling", "Authenticity"],
+	},
+	{
+		slug: "career",
+		title: "Developer Growth and Project Planning",
+		description:
+			"Advice for learning, planning, and shipping as a developer without getting trapped by hype, tutorials, or weak project structure.",
+		summary:
+			"Build stronger judgment around learning, planning, and choosing what to work on so your projects actually compound.",
+		focusAreas: ["Learning strategy", "Project planning", "Career judgment", "Tool choices"],
+	},
+	{
+		slug: "android",
+		title: "Android and Jetpack Compose",
+		description:
+			"Android tutorials focused on Jetpack Compose, Material 3, and animation patterns for building polished mobile UI.",
+		summary:
+			"Browse Android implementation notes and Compose tutorials that emphasize practical UI patterns and shipping details.",
+		focusAreas: ["Jetpack Compose", "Material 3", "Animation", "Android UI"],
+	},
+]
+
+const topicMap = new Map(topics.map((topic) => [topic.slug, topic]))
+
+export function formatTaxonomyLabel(slug: string) {
+	return slug
+		.split("-")
+		.filter(Boolean)
+		.map((part) => part[0]?.toUpperCase() + part.slice(1))
+		.join(" ")
+}
+
+export function normalizeCategorySlug(category: string) {
+	return categoryAliases[category] ?? category
+}
+
+export function normalizeCategoryList(categories: string[]) {
+	return [...new Set(categories.map(normalizeCategorySlug))]
+}
+
+export function getAllTopics() {
+	return topics
+}
+
+export function getTopic(slug: string) {
+	return topicMap.get(slug)
+}
+
+export function getPrimaryTopic(post: Post) {
+	const slug = post.topics?.[0]
+	return slug ? getTopic(slug) ?? null : null
+}
+
+export function getPostsForTopic(posts: Post[], topicSlug: string) {
+	return posts.filter((post) => post.topics?.includes(topicSlug))
+}
+
+export function getRelatedPosts(posts: Post[], currentPost: Post, limit = 3) {
+	const primaryTopic = currentPost.topics?.[0]
+
+	if (!primaryTopic) {
+		return []
+	}
+
+	return posts
+		.filter((post) => post.slug !== currentPost.slug && post.topics?.includes(primaryTopic))
+		.slice(0, limit)
+}

--- a/src/lib/taxonomy.ts
+++ b/src/lib/taxonomy.ts
@@ -6,6 +6,15 @@ export interface TopicDefinition {
 	focusAreas: string[]
 }
 
+export interface TopicOverviewItem extends TopicDefinition {
+	postCount: number
+	latestPost: {
+		title: string
+		slug: string
+		date: string
+	} | null
+}
+
 export const categoryAliases: Record<string, string> = {
 	"careerdevelopment": "career-development",
 	"texutal-healing": "textual-healing",
@@ -80,6 +89,18 @@ const topics: TopicDefinition[] = [
 
 const topicMap = new Map(topics.map((topic) => [topic.slug, topic]))
 
+function getPostActivityDate(post: Post) {
+	return post.updated ?? post.date
+}
+
+function getPostActivityTime(post: Post) {
+	return new Date(getPostActivityDate(post)).getTime()
+}
+
+function getLatestTopicPost(posts: Post[]) {
+	return [...posts].sort((first, second) => getPostActivityTime(second) - getPostActivityTime(first))[0] ?? null
+}
+
 export function formatTaxonomyLabel(slug: string) {
 	return slug
 		.split("-")
@@ -111,6 +132,30 @@ export function getPrimaryTopic(post: Post) {
 
 export function getPostsForTopic(posts: Post[], topicSlug: string) {
 	return posts.filter((post) => post.topics?.includes(topicSlug))
+}
+
+export function getTopicLatestDate(posts: Post[]) {
+	const latestPost = getLatestTopicPost(posts)
+	return latestPost ? getPostActivityDate(latestPost) : null
+}
+
+export function getTopicOverviewItems(posts: Post[]): TopicOverviewItem[] {
+	return topics.map((topic) => {
+		const topicPosts = getPostsForTopic(posts, topic.slug)
+		const latestPost = getLatestTopicPost(topicPosts)
+
+		return {
+			...topic,
+			postCount: topicPosts.length,
+			latestPost: latestPost
+				? {
+						title: latestPost.title,
+						slug: latestPost.slug,
+						date: getPostActivityDate(latestPost),
+					}
+				: null,
+		}
+	})
 }
 
 export function getRelatedPosts(posts: Post[], currentPost: Post, limit = 3) {

--- a/src/posts/awkwardly-awesome.md
+++ b/src/posts/awkwardly-awesome.md
@@ -7,7 +7,9 @@ image: /awkwardly-awesome-banner.webp
 categories:
   - bash
   - tutorial
-  - texutal-healing
+  - textual-healing
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/bash-n-dash.md
+++ b/src/posts/bash-n-dash.md
@@ -8,6 +8,8 @@ categories:
   - bash
   - tutorial
   - shell-wizards
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/bash-script-godot-4-project-creator.md
+++ b/src/posts/bash-script-godot-4-project-creator.md
@@ -7,6 +7,8 @@ image: /bash-script-godot-4-project-creator-banner.webp
 categories:
   - advice
   - career
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/brain-explained.md
+++ b/src/posts/brain-explained.md
@@ -8,6 +8,8 @@ categories:
   - ai
   - open-source
   - productivity
+topics:
+  - ai
 published: true
 ---
 
@@ -165,4 +167,3 @@ It just makes everything smoother.
 ## Last thing
 
 AI is powerful, but without context, it’s just guessing. That's what brain fixes that and once you feel that difference… it’s really hard to go back.
-

--- a/src/posts/brain-explained.md
+++ b/src/posts/brain-explained.md
@@ -2,7 +2,7 @@
 title: "Brain, Explained"
 description: "Brain gives AI coding agents a durable memory and context layer inside the repo, so they can start with the right docs, decisions, and workflow rules instead of starting cold."
 date: "2026-04-16"
-updated: "2026-04-16"
+updated: "2026-04-17"
 image: /brain-explained-banner.webp
 categories:
   - ai
@@ -36,6 +36,8 @@ Brain is super simple. It just lives inside your project and does one job:
 
 That’s it! No crazy UI, no “platform”, no extra thing you have to manage.
 
+If you want to poke around, Brain is open source on GitHub: [JimmyMcBride/brain](https://github.com/JimmyMcBride/brain).
+
 ## Quick example
 
 Let’s say you’re fixing a bug:
@@ -52,7 +54,7 @@ Normally you’d:
 And hope for the best. Now with Brain:
 
 ```bash
-brain context compile --task "fix token refresh race condition"
+brain context compile --task "fix token refresh race condition" --budget small
 ```
 
 That one command pulls together:
@@ -63,7 +65,7 @@ That one command pulls together:
 * your project structure
 * what’s currently changing
 
-Now AI actually understands what it’s working on. That's a huge difference!
+Now AI actually understands what it’s working on. And that `--budget small` part matters too. It tells Brain to start tight instead of dumping the whole kitchen sink into the model.
 
 ## The three things Brain is doing
 
@@ -75,17 +77,25 @@ Your project stops forgetting stuff. Fix a bug? Save it. Make a decision? Save i
 
 ### 2. Retrieval
 
-You can actually find things.
+You can actually find things without remembering the exact phrase you used three weeks ago.
 
 ```bash
 brain search "auth bug"
 ```
 
-Instead of digging through files or trying to remember where something was.
+This is where the hybrid search starts to matter. Brain is using lexical and semantic search together, which really just means it can work when you remember the exact words, and it can still help when you only remember the idea.
+
+* If you search with the real words, the lexical side helps lock onto exact terms and close keyword matches.
+* If your note says `token refresh race condition` and you search `token auth race` or `refresh bug`, the semantic side can still pull you toward the right thing.
+* Put together, it feels a lot more like “find what I mean” and a lot less like “hope I guessed the exact filename.”
 
 ### 3. Context
 
-This is the big one. Instead of throwing your whole project at AI… Brain builds a small, focused packet for whatever you’re working on. Only what matters, no noise.
+This is the big one. Instead of throwing your whole project at AI… Brain builds a packet for whatever you’re working on. A packet is just a small, task-focused bundle of context. Not the whole repo. Not every note you’ve ever written. Just the stuff Brain thinks actually matters for that task.
+
+And this is also where budgets come in. `small`, `default`, and `large` are basically ways to tell Brain how much context it should try to pull together. Smaller packets are usually better than people think, because “more context” sounds smart right up until the model gets distracted by a bunch of irrelevant junk.
+
+So if I’m doing something narrow, I’ll usually start with `small`. If the task is broader, I can loosen it up. And if the budget is tight, Brain can show that some lower-priority stuff got left out instead of burying the useful context under a giant dump of everything. That’s the point: keep the signal, drop the noise.
 
 ## Real world difference
 
@@ -166,4 +176,4 @@ It just makes everything smoother.
 
 ## Last thing
 
-AI is powerful, but without context, it’s just guessing. That's what brain fixes that and once you feel that difference… it’s really hard to go back.
+AI is powerful, but without context, it’s still guessing. That’s what Brain fixes, and once you feel that difference… it’s really hard to go back.

--- a/src/posts/breaking-out-of-tutorial-hell.md
+++ b/src/posts/breaking-out-of-tutorial-hell.md
@@ -7,6 +7,8 @@ image: /tutorial-hell-banner.webp
 categories:
   - advice
   - career
+topics:
+  - career
 published: true
 ---
 

--- a/src/posts/cat-grep-and-go.md
+++ b/src/posts/cat-grep-and-go.md
@@ -1,19 +1,47 @@
 ---
 title: "Cat, Grep, and Go: Leveling Up Your Text Manipulation"
 description: "This post is your ultimate guide to leveling up your command-line game! We’re diving deep into the most commonly used text manipulation tools—cat, grep, and the magic of pipes and redirection. Learn how to efficiently search through text, manipulate files, and combine these tools like a pro. Plus, we’ve included a pro tip on how to use grep --color to make your searches even easier."
+short: "Learn what cat, grep, pipes, and redirection do, when to use them, and how to combine them in practical Bash workflows."
 date: "2024-9-21"
 updated: "2024-9-21"
 image: /cat-grep-and-go-banner.webp
 categories:
   - bash
   - tutorial
-  - texutal-healing
+  - textual-healing
+topics:
+  - bash
 published: true
 ---
 
-Welcome to the first post of the **Textual Healing** series, where we’re diving deep into the world of command-line text manipulation. Today, we’re focusing on three core tools: `cat`, `grep`, and the magic of **piping** and **redirection**.
+`cat` prints file contents, `grep` filters text by word or pattern, and pipes plus redirection let you turn simple commands into repeatable shell workflows. Use them together when you need to inspect files, search logs, and save the exact output you care about without leaving the terminal.
 
-If you’ve spent any time in the terminal, you’ve probably encountered these commands. But have you unlocked their full potential? Whether you’re just getting started or want to level up your command-line skills, we’ll break down these text manipulation wizards and show you how to combine them like a pro.
+This guide starts with the beginner-friendly commands, then moves into the combinations that are actually useful in everyday Bash work.
+
+## Quick answer
+
+- `cat` is the fastest way to print small file contents directly to the terminal.
+- `grep` is the command-line search tool you reach for when you need matching lines from files or streamed output.
+- Pipes (`|`) and redirection (`>`, `>>`) are what turn one-off commands into useful workflows.
+
+## Who this is for
+
+- Developers who are comfortable opening a terminal but want better day-to-day command-line instincts
+- Beginners learning Bash or shell basics
+- Anyone who keeps bouncing between logs, config files, and code search
+
+## Prerequisites
+
+- You can open a terminal and run basic commands
+- You know what a file and directory are
+- You have a small text file or log file to experiment with
+
+## What you'll learn
+
+- when to use `cat` and when not to
+- how `grep` helps you search faster
+- how pipes and redirection fit together
+- which beginner mistakes waste time in real shell work
 
 ---
 
@@ -150,17 +178,41 @@ Let’s break this down:
 - **`> errors.txt`**: This uses **redirection** to save the output of `grep` to the file `errors.txt`.
 - **`&& cat errors.txt`**: The `&&` ensures that the file is created first, then we use `cat` to display the contents of `errors.txt` back to the terminal, effectively letting you both see the results and save them at the same time.
 
-This command allows you to search through all `.log` files for "error," save the results to `errors.txt`, and then view them immediately.
+This command allows you to search through all `.log` files for “error,” save the results to `errors.txt`, and then view them immediately.
 
 ---
 
-### **Coming Soon: A `sed` Deep Dive**
+## Common mistakes
 
-As promised, the next post will be all about `sed`—a powerful stream editor for transforming and manipulating text. We’ll cover everything from basic substitutions to advanced text transformations. Stay tuned!
+- Using `cat file | grep "word"` when `grep "word" file` is simpler. Pipes are useful, but they are not always necessary.
+- Forgetting that `>` overwrites a file while `>>` appends to it.
+- Searching without quotes when the pattern contains spaces or characters your shell might expand.
+- Using `cat` on huge files when `less` or targeted `grep` output would be easier to scan.
 
 ---
 
-### **Join the Community!**
+## FAQ
+
+### Should I use `cat` or `less`?
+
+Use `cat` when the file is small and you just want the output immediately. Use `less` when you need to scroll, search, or inspect a larger file without dumping everything into the terminal at once.
+
+### Do I always need `cat` before `grep`?
+
+No. Most of the time, `grep "pattern" file.txt` is cleaner than `cat file.txt | grep "pattern"`. Reach for the pipe when the input is already coming from another command.
+
+### What is the real benefit of redirection?
+
+Redirection turns disposable terminal output into something you can keep, reuse, diff, or send into another workflow.
+
+## Next steps
+
+- If you are new to the shell, read [Shell We Begin? Discover the Power of the Command Line](/blog/shell-we-begin) next.
+- If you want more command-line fundamentals, continue with [Bash-n-Dash: Fast-Track Your Way to Shell Mastery](/blog/bash-n-dash).
+- If you want another text-processing tool after `grep`, read [Sed It Right: Mastering the Stream Editor for Text Magic](/blog/sed-it-right).
+- If you want the bigger picture for this cluster, browse the [Bash and Shell Automation topic hub](/topics/bash).
+
+## Join the Community!
 
 If you’re into coding, Linux, and just love being around people who want to learn, grow, and help each other out, come hang out with us on Discord! It’s a community of like-minded folks who share tips, talk shop, and support each other on our coding journeys. Whether you're a beginner or a seasoned pro, there's a place for you.
 

--- a/src/posts/choosing-the-right-framework.md
+++ b/src/posts/choosing-the-right-framework.md
@@ -7,6 +7,8 @@ image: /choosing-the-right-framework-banner.webp
 categories:
   - advice
   - career
+topics:
+  - career
 published: true
 ---
 

--- a/src/posts/create-custom-jetpack-compose-animations-make-your-app-experience-truly-unique.md
+++ b/src/posts/create-custom-jetpack-compose-animations-make-your-app-experience-truly-unique.md
@@ -9,6 +9,8 @@ categories:
   - android
   - animation
   - tutorial
+topics:
+  - android
 published: true
 ---
 

--- a/src/posts/hitchhikers-guide-to-the-arch-linux-installation.md
+++ b/src/posts/hitchhikers-guide-to-the-arch-linux-installation.md
@@ -8,6 +8,8 @@ categories:
   - linux
   - arch
   - tutorial
+topics:
+  - linux
 published: true
 ---
 

--- a/src/posts/how-to-use-ai-writing-tools.md
+++ b/src/posts/how-to-use-ai-writing-tools.md
@@ -8,6 +8,8 @@ image: /how-to-use-ai-writing-tools-banner.webp
 categories:
   - ai
   - opinion
+topics:
+  - ai
 published: true
 ---
 

--- a/src/posts/i-survived-a-massive-ddos-attack.md
+++ b/src/posts/i-survived-a-massive-ddos-attack.md
@@ -8,6 +8,8 @@ image: /i-survived-a-massive-ddos-attack-banner.webp
 categories:
   - linux
   - security
+topics:
+  - self-hosting
 published: true
 ---
 

--- a/src/posts/linux-i-choose-you.md
+++ b/src/posts/linux-i-choose-you.md
@@ -8,6 +8,8 @@ categories:
   - linux
   - opinion
   - discuss
+topics:
+  - linux
 published: true
 ---
 

--- a/src/posts/planning-a-project-from-scratch.md
+++ b/src/posts/planning-a-project-from-scratch.md
@@ -6,9 +6,11 @@ updated: "2023-5-10"
 image: /planning-a-project-from-scratch-banner.webp
 categories:
   - career
-  - careerdevelopment
+  - career-development
   - tutorial
   - productivity
+topics:
+  - career
 published: true
 ---
 

--- a/src/posts/sed-it-right.md
+++ b/src/posts/sed-it-right.md
@@ -8,6 +8,8 @@ categories:
   - linux
   - arch
   - tutorial
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/self-host-your-digital-empire.md
+++ b/src/posts/self-host-your-digital-empire.md
@@ -8,6 +8,8 @@ image: /self-host-your-digital-empire-banner.webp
 categories:
   - open-source
   - opinion
+topics:
+  - self-hosting
 published: true
 ---
 

--- a/src/posts/shell-we-begin.md
+++ b/src/posts/shell-we-begin.md
@@ -8,6 +8,8 @@ categories:
   - tutorial
   - bash
   - shell-wizards
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/sveltekit-blog.md
+++ b/src/posts/sveltekit-blog.md
@@ -8,6 +8,8 @@ categories:
   - svelte
   - sveltekit
   - tutorial
+topics:
+  - sveltekit-blogging
 published: true
 ---
 

--- a/src/posts/swipe-away-tasks-jetpack-compose-material-3-todo-app-quick-start-guide.md
+++ b/src/posts/swipe-away-tasks-jetpack-compose-material-3-todo-app-quick-start-guide.md
@@ -9,6 +9,8 @@ categories:
   - android
   - animation
   - tutorial
+topics:
+  - android
 published: true
 ---
 

--- a/src/posts/the-key-to-completing-projects-matering-the-art-of-planning.md
+++ b/src/posts/the-key-to-completing-projects-matering-the-art-of-planning.md
@@ -9,6 +9,8 @@ categories:
   - productivity
   - career
   - codenewbie
+topics:
+  - career
 published: true
 ---
 

--- a/src/posts/the-ultimate-devto-hacks.md
+++ b/src/posts/the-ultimate-devto-hacks.md
@@ -7,6 +7,8 @@ image: /the-ultimate-devto-hacks-banner.webp
 categories:
   - seo
   - tutorial
+topics:
+  - sveltekit-blogging
 published: true
 ---
 

--- a/src/posts/the-undisputed-best-way-to-learn-how-to-code.md
+++ b/src/posts/the-undisputed-best-way-to-learn-how-to-code.md
@@ -9,6 +9,8 @@ categories:
   - productivity
   - career
   - codenewbie
+topics:
+  - career
 published: true
 ---
 

--- a/src/posts/why-i-bash-git.md
+++ b/src/posts/why-i-bash-git.md
@@ -5,9 +5,11 @@ date: "2024-9-15"
 updated: "2024-9-15"
 image: /why-i-bash-git-banner.webp
 categories:
-  - tutoiral
+  - tutorial
   - bash
   - git
+topics:
+  - bash
 published: true
 ---
 

--- a/src/posts/writing-your-own-tools.md
+++ b/src/posts/writing-your-own-tools.md
@@ -7,6 +7,8 @@ image: /writing-your-own-tools-banner.webp
 categories:
   - advice
   - career
+topics:
+  - career
 published: true
 ---
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,32 +1,44 @@
 <script lang="ts">
 	import MyLinks from "$lib/components/MyLinks.svelte"
-	import { description, title, url } from "$lib/config"
+	import { title } from "$lib/config"
+	import { createSeo, createWebsiteJsonLd, renderJsonLdScript } from "$lib/seo"
 	import { ScaleBalancedSolid, ComputerSpeakerSolid, BrainSolid } from "flowbite-svelte-icons"
 	import Subscribe from "$lib/components/Subscribe.svelte"
+
+	const seo = createSeo({
+		path: "/",
+		title,
+		description:
+			"Jimmy McBride writes about SvelteKit, Bash, Linux, self-hosting, and practical software engineering from first-hand experience.",
+		image: "/me.webp",
+	})
+	const websiteJsonLd = createWebsiteJsonLd()
 </script>
 
 <svelte:head>
-	<title>{title}</title>
+	<title>{seo.title}</title>
 
-	<meta name="description" content={description} />
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
 
-	<meta property="og:type" content="article" />
-	<meta property="og:url" content={`${url}/blog`} />
-	<meta property="og:title" content={title} />
-	<meta property="og:description" content={description} />
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
 	<meta property="og:site_name" content={title} />
-	<meta property="og:image" content="/blog-banner.webp" />
+	<meta property="og:image" content={seo.image} />
 
 	<meta name="twitter:site" content="@McBride1105" />
 	<meta name="twitter:creator" content="@McBride1105" />
-	<meta name="twitter:title" content={title} />
-	<meta name="twitter:description" content={description} />
-	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:image:src" content="/blog-banner.webp" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
+	<meta name="twitter:image:src" content={seo.image} />
 	<meta name="twitter:widgets:new-embed-design" content="on" />
 
 	<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+	{@html renderJsonLdScript(websiteJsonLd)}
 </svelte:head>
 
 <section class="flex justify-center mt-16 flex-wrap">

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -1,30 +1,8 @@
 import { json } from "@sveltejs/kit"
-
-async function getPosts() {
-	let posts: Post[] = []
-
-	const paths = import.meta.glob("/src/posts/*.md", { eager: true })
-
-	for (const path in paths) {
-		const file = paths[path]
-		const slug = path.split("/").at(-1)?.replace(".md", "")
-
-		if (file && typeof file === "object" && "metadata" in file && slug) {
-			const metadata = file.metadata as Omit<Post, "slug">
-			const post = { ...metadata, slug } satisfies Post
-			post.published && posts.push(post)
-		}
-	}
-
-	posts = posts.sort(
-		(first, second) => new Date(second.date).getTime() - new Date(first.date).getTime()
-	)
-
-	return posts
-}
+import { getPublishedPosts } from "$lib/posts"
 
 export async function GET() {
-	const posts = await getPosts()
+	const posts = getPublishedPosts()
 	return json(posts)
 }
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
 	import BlogCard from "$lib/components/BlogCard.svelte"
 	import { Button } from "$lib/components/ui/button"
-	import { title, description, url } from "$lib/config"
+	import { title } from "$lib/config"
+	import { createSeo } from "$lib/seo"
 
 	let { data } = $props()
 	const pageSize = 8
+	const seo = createSeo({
+		path: "/blog",
+		title: `Blog | ${title}`,
+		description:
+			"Technical tutorials, developer essays, and practical notes on SvelteKit, Bash, Linux, AI tools, and self-hosting.",
+	})
 
 	let currentPage = $state(1)
 	let searchTerm = $state("")
@@ -27,23 +34,24 @@
 </script>
 
 <svelte:head>
-	<title>{title}</title>
+	<title>{seo.title}</title>
 
-	<meta name="description" content={description} />
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
 
-	<meta property="og:type" content="article" />
-	<meta property="og:url" content={`${url}/blog`} />
-	<meta property="og:title" content={title} />
-	<meta property="og:description" content={description} />
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
 	<meta property="og:site_name" content={title} />
-	<meta property="og:image" content="/blog-banner.webp" />
+	<meta property="og:image" content={seo.image} />
 
 	<meta name="twitter:site" content="@McBride1105" />
 	<meta name="twitter:creator" content="@McBride1105" />
-	<meta name="twitter:title" content={title} />
-	<meta name="twitter:description" content={description} />
-	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:image:src" content="/blog-banner.webp" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
+	<meta name="twitter:image:src" content={seo.image} />
 	<meta name="twitter:widgets:new-embed-design" content="on" />
 
 	<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
@@ -51,6 +59,20 @@
 </svelte:head>
 
 <section class="mb-16">
+	<div class="mx-4 mb-8 rounded-lg border border-border bg-card p-6">
+		<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+			<div>
+				<h2 class="text-2xl font-bold">Browse by topic</h2>
+				<p class="text-muted-foreground">
+					Follow the site's main subjects through focused hub pages instead of hunting through the full archive.
+				</p>
+			</div>
+			<a class="font-semibold text-primary underline-offset-4 hover:underline" href="/topics">
+				View topic hubs
+			</a>
+		</div>
+	</div>
+
 	<!-- Search Input -->
 	<div class="flex justify-center mb-4 mx-4">
 		<label class="sr-only" for="blog-search">Search blog posts</label>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -131,6 +131,12 @@
 			</button>
 		</div>
 	{:else}
+		{#if showPagination}
+			<div class="mx-auto mb-6 max-w-4xl">
+				<PaginationNav currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+			</div>
+		{/if}
+
 		<ul class="flex flex-col items-center px-4 pb-2">
 			{#each paginatedPosts as post}
 				<BlogCard {post} />

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+	import ArchiveSearchInput from "$lib/components/archive/ArchiveSearchInput.svelte"
+	import PaginationNav from "$lib/components/archive/PaginationNav.svelte"
 	import BlogCard from "$lib/components/BlogCard.svelte"
-	import { Button } from "$lib/components/ui/button"
+	import { buttonVariants } from "$lib/components/ui/button"
 	import { title } from "$lib/config"
 	import { createSeo } from "$lib/seo"
+	import { cn } from "$lib/utils"
 
 	let { data } = $props()
 	const pageSize = 8
@@ -17,12 +20,19 @@
 	let searchTerm = $state("")
 
 	let filteredPosts = $derived(
-		data.posts.filter((post: { title: string }) =>
-			post.title.toLowerCase().includes(searchTerm.toLowerCase())
+		data.posts.filter((post: { title: string; description: string }) =>
+			`${post.title} ${post.description}`.toLowerCase().includes(searchTerm.toLowerCase())
 		)
 	)
 
-	let totalPages = $derived(Math.ceil(filteredPosts.length / pageSize))
+	let totalPages = $derived(Math.max(1, Math.ceil(filteredPosts.length / pageSize)))
+	let showPagination = $derived(filteredPosts.length > pageSize)
+	let resultsLabel = $derived(
+		searchTerm.trim()
+			? `${filteredPosts.length} result${filteredPosts.length === 1 ? "" : "s"} for "${searchTerm.trim()}"`
+			: `${data.posts.length} post${data.posts.length === 1 ? "" : "s"} in the archive`
+	)
+	let pageLabel = $derived(showPagination ? `Page ${currentPage} of ${totalPages}` : "")
 
 	let paginatedPosts = $derived(
 		filteredPosts.slice((currentPage - 1) * pageSize, currentPage * pageSize)
@@ -31,6 +41,19 @@
 	$effect(() => {
 		if (searchTerm) currentPage = 1
 	})
+
+	function handleSearchChange(value: string) {
+		searchTerm = value
+	}
+
+	function clearSearch() {
+		searchTerm = ""
+		currentPage = 1
+	}
+
+	function handlePageChange(page: number) {
+		currentPage = Math.min(Math.max(page, 1), totalPages)
+	}
 </script>
 
 <svelte:head>
@@ -59,63 +82,65 @@
 </svelte:head>
 
 <section class="mb-16">
-	<div class="mx-4 mb-8 rounded-lg border border-border bg-card p-6">
-		<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
-			<div>
-				<h2 class="text-2xl font-bold">Browse by topic</h2>
-				<p class="text-muted-foreground">
-					Follow the site's main subjects through focused hub pages instead of hunting through the full archive.
-				</p>
+	<div class="mx-4 mb-8 rounded-[1.75rem] border border-border/70 bg-card/70 p-5 md:p-6">
+		<div class="flex flex-col gap-5">
+			<div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+				<div class="space-y-2">
+					<p class="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">Archive</p>
+					<h2 class="text-2xl font-bold sm:text-3xl">Search the full archive</h2>
+					<p class="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+						Browse every post in one place, or switch to topic hubs when you want a tighter subject view.
+					</p>
+				</div>
+
+				<a
+					class={cn(buttonVariants("outline", "sm"), "w-fit rounded-full px-4 no-underline")}
+					href="/topics"
+				>
+					Explore topic hubs
+				</a>
 			</div>
-			<a class="font-semibold text-primary underline-offset-4 hover:underline" href="/topics">
-				View topic hubs
-			</a>
+
+			<div class="border-t border-border/70 pt-5">
+				<ArchiveSearchInput
+					id="blog-search"
+					label="Search blog posts"
+					placeholder="Search titles and summaries"
+					value={searchTerm}
+					{resultsLabel}
+					{pageLabel}
+					onValueChange={handleSearchChange}
+					onClear={clearSearch}
+				/>
+			</div>
 		</div>
 	</div>
 
-	<!-- Search Input -->
-	<div class="flex justify-center mb-4 mx-4">
-		<label class="sr-only" for="blog-search">Search blog posts</label>
-		<input
-			id="blog-search"
-			type="search"
-			name="search"
-			bind:value={searchTerm}
-			placeholder="Search blogs..."
-			class="flex h-10 w-full max-w-lg rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-		/>
-	</div>
+	{#if filteredPosts.length === 0}
+		<div class="mx-4 rounded-[1.5rem] border border-dashed border-border bg-card/60 p-8 text-center">
+			<h3 class="text-xl font-bold">No posts matched</h3>
+			<p class="mx-auto mt-3 max-w-xl text-sm leading-7 text-muted-foreground sm:text-base">
+				Try a broader search term or clear the current filter.
+			</p>
+			<button
+				type="button"
+				class="mt-5 inline-flex rounded-full border border-border px-4 py-2 text-sm font-medium transition-colors hover:border-primary/40 hover:text-primary"
+				onclick={clearSearch}
+			>
+				Clear search
+			</button>
+		</div>
+	{:else}
+		<ul class="flex flex-col items-center px-4 pb-2">
+			{#each paginatedPosts as post}
+				<BlogCard {post} />
+			{/each}
+		</ul>
 
-	<!-- Pagination (top) -->
-	<div class="flex justify-center items-center space-x-4 mt-4">
-		{#if currentPage > 1}
-			<Button aria-label="Previous page" onclick={() => currentPage--}>Previous</Button>
+		{#if showPagination}
+			<div class="mx-4">
+				<PaginationNav currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+			</div>
 		{/if}
-
-		{#if currentPage < totalPages}
-			<Button aria-label="Next page" onclick={() => currentPage++}>Next</Button>
-		{/if}
-
-		<p class="font-mono text-sm">Page: {currentPage}/{totalPages}</p>
-	</div>
-
-	<!-- Blog List -->
-	<ul class="flex flex-col items-center p-4">
-		{#each paginatedPosts as post}
-			<BlogCard {post} />
-		{/each}
-	</ul>
-
-	<!-- Pagination (bottom) -->
-	<div class="flex justify-center items-center space-x-4 mt-4">
-		{#if currentPage > 1}
-			<Button aria-label="Previous page" onclick={() => currentPage--}>Previous</Button>
-		{/if}
-
-		{#if currentPage < totalPages}
-			<Button aria-label="Next page" onclick={() => currentPage++}>Next</Button>
-		{/if}
-
-		<p class="font-mono text-sm">Page: {currentPage}/{totalPages}</p>
-	</div>
+	{/if}
 </section>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -82,7 +82,7 @@
 </svelte:head>
 
 <section class="mb-16">
-	<div class="mx-4 mb-8 rounded-[1.75rem] border border-border/70 bg-card/70 p-5 md:p-6">
+	<div class="mx-auto mb-8 max-w-4xl rounded-[1.75rem] border border-border/70 bg-card/70 p-5 md:p-6">
 		<div class="flex flex-col gap-5">
 			<div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
 				<div class="space-y-2">
@@ -117,7 +117,7 @@
 	</div>
 
 	{#if filteredPosts.length === 0}
-		<div class="mx-4 rounded-[1.5rem] border border-dashed border-border bg-card/60 p-8 text-center">
+		<div class="mx-auto max-w-4xl rounded-[1.5rem] border border-dashed border-border bg-card/60 p-8 text-center">
 			<h3 class="text-xl font-bold">No posts matched</h3>
 			<p class="mx-auto mt-3 max-w-xl text-sm leading-7 text-muted-foreground sm:text-base">
 				Try a broader search term or clear the current filter.
@@ -138,7 +138,7 @@
 		</ul>
 
 		{#if showPagination}
-			<div class="mx-4">
+			<div class="mx-auto max-w-4xl">
 				<PaginationNav currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
 			</div>
 		{/if}

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { browser } from "$app/environment"
 	import { formatDate } from "$lib/utils"
-	import { url, title } from "$lib/config"
+	import { title } from "$lib/config"
+	import { createBlogPostingJsonLd, createSeo, renderJsonLdScript } from "$lib/seo"
+	import { formatTaxonomyLabel } from "$lib/taxonomy"
 	import { page } from "$app/stores"
 	import { handleDiscordLogin, handleLogout } from "$lib/pocketbase"
 	import { user } from "$lib/stores/user"
@@ -14,7 +16,25 @@
 	let slug = $derived($page.params.slug)
 	let content = $derived(data.content)
 	let meta = $derived(data.meta)
-	let views = $derived(data.views)
+	let seo = $derived(
+		createSeo({
+			path: `/blog/${slug}`,
+			title: meta.title,
+			description: meta.short ? meta.short : meta.description,
+			image: meta.image,
+			type: "article",
+			publishedTime: meta.date,
+			modifiedTime: meta.updated ? meta.updated : meta.date,
+		})
+	)
+	let blogPostingJsonLd = $derived(
+		createBlogPostingJsonLd({
+			...meta,
+			slug,
+		})
+	)
+	let primaryTopic = $derived(data.primaryTopic)
+	let relatedPosts = $derived(data.relatedPosts ?? [])
 	let newComment = $state("")
 	let comments = $state<unknown[]>([])
 	let loadedCommentsFor = $state<string | null>(null)
@@ -79,33 +99,38 @@
 
 <!-- SEO -->
 <svelte:head>
-	<title>{meta.title}</title>
+	<title>{seo.title}</title>
 
-	<link rel="canonical" href={`${url}${url}`} />
-	<meta name="description" content={meta.short ? meta.short : meta.description} />
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
 
-	<meta property="og:type" content="article" />
-	<meta property="og:url" content={`${url}${url}`} />
-	<meta property="og:title" content={meta.title} />
-	<meta property="og:description" content={meta.short ? meta.short : meta.description} />
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
 	<meta property="og:site_name" content={title} />
 
 	<meta name="twitter:site" content="@McBride1105" />
 	<meta name="twitter:creator" content="@McBride1105" />
-	<meta name="twitter:title" content={meta.title} />
-	<meta name="twitter:description" content={meta.short ? meta.short : meta.description} />
-	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
 	<meta name="twitter:widgets:new-embed-design" content="on" />
 
-	<meta property="article:published_time" content={meta.updated} />
-	<meta property="article:modified_time" content={meta.updated} />
-	<meta name="date" content={meta.updated} />
+	{#if seo.publishedTime}
+		<meta property="article:published_time" content={seo.publishedTime} />
+	{/if}
+	{#if seo.modifiedTime}
+		<meta property="article:modified_time" content={seo.modifiedTime} />
+		<meta name="date" content={seo.modifiedTime} />
+	{/if}
 
-	<meta property="og:image" content={meta.image} />
-	<meta name="twitter:image:src" content={meta.image} />
+	<meta property="og:image" content={seo.image} />
+	<meta name="twitter:image:src" content={seo.image} />
 
 	<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
 	<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+	{@html renderJsonLdScript(blogPostingJsonLd)}
 </svelte:head>
 
 <article class="mx-auto mb-16 w-full max-w-6xl p-4">
@@ -125,21 +150,51 @@
 		<p class="text-right text-sm">
 			Published at {formatDate(meta.date)}
 			<br />
-			Total Views:
-			{#if views !== undefined}
-				{views}
-			{/if}
+			Updated at {formatDate(meta.updated ? meta.updated : meta.date)}
 		</p>
 	</header>
 
 	<!-- Tags -->
 	<div class="mx-auto mb-6 flex w-full max-w-5xl flex-wrap gap-4">
+		{#if primaryTopic}
+			<a href={`/topics/${primaryTopic.slug}`} class="no-underline">
+				<Badge>#topic: {primaryTopic.title}</Badge>
+			</a>
+		{/if}
 		{#each meta.categories as category}
 			<a href={`/blog/categories/${category}`} class="no-underline">
 				<Badge variant="secondary">&num;{category}</Badge>
 			</a>
 		{/each}
 	</div>
+
+	{#if primaryTopic}
+		<section class="mx-auto mb-10 w-full max-w-5xl rounded-lg border border-border bg-card p-6">
+			<p class="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+				Primary topic
+			</p>
+			<h2 class="mb-3 text-2xl font-bold">{primaryTopic.title}</h2>
+			<p class="mb-4 text-muted-foreground">{primaryTopic.summary}</p>
+			<a class="font-semibold text-primary underline-offset-4 hover:underline" href={`/topics/${primaryTopic.slug}`}>
+				Explore the {formatTaxonomyLabel(primaryTopic.slug)} hub
+			</a>
+
+			{#if relatedPosts.length}
+				<div class="mt-6">
+					<h3 class="mb-3 text-lg font-semibold">Related posts</h3>
+					<ul class="space-y-2">
+						{#each relatedPosts as post}
+							<li>
+								<a class="font-medium text-primary underline-offset-4 hover:underline" href={`/blog/${post.slug}`}>
+									{post.title}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		</section>
+	{/if}
 
 	<!-- Post -->
 	<div class="mx-auto w-full max-w-5xl">

--- a/src/routes/blog/[slug]/+page.ts
+++ b/src/routes/blog/[slug]/+page.ts
@@ -1,34 +1,28 @@
 import { error } from "@sveltejs/kit"
 import type { LoadEvent } from "@sveltejs/kit"
+import { getPublishedPosts } from "$lib/posts"
+import { getPrimaryTopic, getRelatedPosts } from "$lib/taxonomy"
 
 export const load = async ({ params, fetch }: LoadEvent) => {
 	try {
 		// Load the mdsvex markdown post (Svelte component)
 		const post = await import(`../../../posts/${params.slug}.md`)
-
-		// Fetch Plausible analytics data
-		const slug = params.slug
-
-		// Fetch dynamic analytics client-side through the route-scoped fetch.
-		let views = 0
-		let readers = 0
-
-		if (!import.meta.env.SSR) {
-			const res = await fetch(`/api/views/${slug}`)
-
-			const data = await res.json()
-			views = data.views
-			readers = data.readers
-
-		}
+		const currentPost = {
+			...post.metadata,
+			slug: params.slug,
+		} as Post
 
 		// Return the markdown component and serializable data
+		const posts = getPublishedPosts()
+		const primaryTopic = getPrimaryTopic(currentPost)
+		const relatedPosts = getRelatedPosts(posts, currentPost)
+
 		return {
 			content: post.default, // This is the Svelte component for the blog content
 			meta: post.metadata,
-			views,
-			readers,
 			comments: [],
+			primaryTopic,
+			relatedPosts,
 		}
 	} catch (e) {
 		console.error(e)

--- a/src/routes/blog/categories/[category]/+page.svelte
+++ b/src/routes/blog/categories/[category]/+page.svelte
@@ -1,13 +1,48 @@
 <script lang="ts">
 	import BlogCard from "$lib/components/BlogCard.svelte"
+	import { title } from "$lib/config"
+	import { createSeo, formatCategoryLabel } from "$lib/seo"
 	import type { PageData } from "./$types"
 
 	let { data }: { data: PageData } = $props()
+	let label = $derived(formatCategoryLabel(data.category))
+	let seo = $derived(
+		createSeo({
+			path: `/blog/categories/${data.category}`,
+			title: `${label} Articles | ${title}`,
+			description: `Browse Jimmy McBride's posts about ${label.toLowerCase()}, including tutorials, notes, and related developer writing.`,
+		})
+	)
 </script>
+
+<svelte:head>
+	<title>{seo.title}</title>
+
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
+
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
+	<meta property="og:site_name" content={title} />
+	<meta property="og:image" content={seo.image} />
+
+	<meta name="twitter:site" content="@McBride1105" />
+	<meta name="twitter:creator" content="@McBride1105" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
+	<meta name="twitter:image:src" content={seo.image} />
+	<meta name="twitter:widgets:new-embed-design" content="on" />
+</svelte:head>
 
 {#if data.posts.length}
 	<aside class="mb-16 text-center">
-		<h2>{data.category}</h2>
+		<h1 class="text-4xl font-bold mb-4">{label}</h1>
+		<p class="mx-auto mb-8 max-w-2xl text-muted-foreground">
+			Posts, tutorials, and notes connected to {label.toLowerCase()}.
+		</p>
 		<ul class="flex flex-col items-center">
 			{#each data.posts as post}
 				<BlogCard {post} />

--- a/src/routes/blog/categories/[category]/+page.ts
+++ b/src/routes/blog/categories/[category]/+page.ts
@@ -1,5 +1,6 @@
 import type { ServerLoadEvent } from "@sveltejs/kit"
-import { error } from "@sveltejs/kit"
+import { error, redirect } from "@sveltejs/kit"
+import { normalizeCategorySlug } from "$lib/taxonomy"
 
 export const load = async ({ params, fetch }: ServerLoadEvent) => {
 	const { category } = params
@@ -10,10 +11,18 @@ export const load = async ({ params, fetch }: ServerLoadEvent) => {
 		throw error(404, "Category not found")
 	}
 
-	const posts = allPosts.filter((post: Post) => post.categories.includes(category))
+	const normalizedCategory = normalizeCategorySlug(category)
+
+	if (normalizedCategory !== category) {
+		throw redirect(308, `/blog/categories/${normalizedCategory}`)
+	}
+
+	const posts = allPosts.filter((post: Post) =>
+		post.categories.some((postCategory) => normalizeCategorySlug(postCategory) === normalizedCategory)
+	)
 
 	return {
-		category,
+		category: normalizedCategory,
 		posts,
 	}
 }

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,17 +1,37 @@
 import { url } from "$lib/config"
+import { getMostRecentPostDate, getPublishedPosts, getUniqueCategories } from "$lib/posts"
+import { getAllTopics } from "$lib/taxonomy"
 import { SitemapStream, streamToPromise } from "sitemap"
 import { Readable } from "stream"
 import type { RequestEvent } from "@sveltejs/kit"
 
-export const GET = async ({ fetch }: RequestEvent) => {
-	const response = await fetch("/api/posts")
-	const posts: Post[] = await response.json()
+export const GET = async (_event: RequestEvent) => {
+	const posts = getPublishedPosts()
+	const categories = getUniqueCategories(posts)
+	const topics = getAllTopics()
+	const lastmod = getMostRecentPostDate(posts)
+	const coreRoutes = ["/", "/blog", "/topics"]
+	const categoryRoutes = categories.map((category) => `/blog/categories/${category}`)
+	const topicRoutes = topics.map((topic) => `/topics/${topic.slug}`)
 
-	const links = posts.map((post: Post) => ({
-		url: `/blog/${post.slug}`,
-		changefreq: "weekly",
-		priority: 0.8,
-	}))
+	const links = [
+		...coreRoutes.map((route) => ({
+			url: route,
+			lastmod,
+		})),
+		...topicRoutes.map((route) => ({
+			url: route,
+			lastmod,
+		})),
+		...categoryRoutes.map((route) => ({
+			url: route,
+			lastmod,
+		})),
+		...posts.map((post) => ({
+			url: `/blog/${post.slug}`,
+			lastmod: post.updated ?? post.date,
+		})),
+	]
 
 	const stream = new SitemapStream({ hostname: url })
 

--- a/src/routes/topics/+page.svelte
+++ b/src/routes/topics/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { title } from "$lib/config"
+	import { createSeo } from "$lib/seo"
+	import { getAllTopics } from "$lib/taxonomy"
+
+	const topics = getAllTopics()
+	const seo = createSeo({
+		path: "/topics",
+		title: `Topics | ${title}`,
+		description:
+			"Browse Jimmy McBride's core topic hubs for Bash, Linux, SvelteKit, self-hosting, AI for developers, career growth, and Android.",
+	})
+</script>
+
+<svelte:head>
+	<title>{seo.title}</title>
+
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
+
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
+	<meta property="og:site_name" content={title} />
+	<meta property="og:image" content={seo.image} />
+
+	<meta name="twitter:site" content="@McBride1105" />
+	<meta name="twitter:creator" content="@McBride1105" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
+	<meta name="twitter:image:src" content={seo.image} />
+</svelte:head>
+
+<section class="mx-auto mb-16 max-w-6xl p-4">
+	<header class="mb-10 space-y-4 text-center">
+		<h1 class="text-4xl font-bold sm:text-5xl">Topic Hubs</h1>
+		<p class="mx-auto max-w-3xl text-muted-foreground">
+			Start with the subjects that define the site, then branch into the related tutorials, essays,
+			and implementation notes behind each one.
+		</p>
+	</header>
+
+	<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+		{#each topics as topic}
+			<a
+				href={`/topics/${topic.slug}`}
+				class="rounded-lg border border-border bg-card p-6 no-underline transition-colors hover:border-primary/40 hover:bg-accent/30"
+			>
+				<h2 class="mb-3 text-2xl font-bold">{topic.title}</h2>
+				<p class="mb-4 text-muted-foreground">{topic.summary}</p>
+				<ul class="space-y-1 text-sm text-muted-foreground">
+					{#each topic.focusAreas as focusArea}
+						<li>{focusArea}</li>
+					{/each}
+				</ul>
+			</a>
+		{/each}
+	</div>
+</section>

--- a/src/routes/topics/+page.svelte
+++ b/src/routes/topics/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { buttonVariants } from "$lib/components/ui/button"
 	import { title } from "$lib/config"
 	import { createSeo } from "$lib/seo"
-	import { getAllTopics } from "$lib/taxonomy"
+	import { cn, formatDate } from "$lib/utils.js"
+	import type { PageData } from "./$types"
 
-	const topics = getAllTopics()
+	let { data }: { data: PageData } = $props()
 	const seo = createSeo({
 		path: "/topics",
 		title: `Topics | ${title}`,
@@ -34,28 +36,93 @@
 </svelte:head>
 
 <section class="mx-auto mb-16 max-w-6xl p-4">
-	<header class="mb-10 space-y-4 text-center">
-		<h1 class="text-4xl font-bold sm:text-5xl">Topic Hubs</h1>
-		<p class="mx-auto max-w-3xl text-muted-foreground">
-			Start with the subjects that define the site, then branch into the related tutorials, essays,
-			and implementation notes behind each one.
-		</p>
+	<header class="grid gap-6 rounded-[2rem] border border-border/80 bg-card/60 p-6 md:p-8 lg:grid-cols-[minmax(0,1.65fr)_minmax(18rem,1fr)] lg:items-start">
+		<div class="space-y-4">
+			<p class="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">Topic hubs</p>
+			<h1 class="max-w-3xl text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+				Browse the site by subject
+			</h1>
+			<p class="max-w-2xl text-base leading-8 text-muted-foreground sm:text-lg">
+				Topic hubs group related tutorials, essays, and implementation notes so you can move through the site with a clear subject in mind instead of digging through the full archive.
+			</p>
+		</div>
+
+		<aside class="rounded-[1.5rem] border border-border/70 bg-background/80 p-5">
+			<h2 class="text-sm font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+				How to use this page
+			</h2>
+			<ul class="mt-4 space-y-3 text-sm leading-7 text-muted-foreground">
+				<li class="flex gap-3">
+					<span class="font-mono text-xs text-foreground">01</span>
+					<span>Start with the topic closest to the problem you are trying to solve right now.</span>
+				</li>
+				<li class="flex gap-3">
+					<span class="font-mono text-xs text-foreground">02</span>
+					<span>Use topic pages to browse focused posts instead of scanning the full archive.</span>
+				</li>
+				<li class="flex gap-3">
+					<span class="font-mono text-xs text-foreground">03</span>
+					<span>Each hub surfaces the latest and most relevant posts for that subject.</span>
+				</li>
+			</ul>
+		</aside>
 	</header>
 
-	<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-		{#each topics as topic}
-			<a
-				href={`/topics/${topic.slug}`}
-				class="rounded-lg border border-border bg-card p-6 no-underline transition-colors hover:border-primary/40 hover:bg-accent/30"
-			>
-				<h2 class="mb-3 text-2xl font-bold">{topic.title}</h2>
-				<p class="mb-4 text-muted-foreground">{topic.summary}</p>
-				<ul class="space-y-1 text-sm text-muted-foreground">
-					{#each topic.focusAreas as focusArea}
-						<li>{focusArea}</li>
-					{/each}
-				</ul>
-			</a>
+	<div class="mt-10 space-y-4">
+		{#each data.topics as topic}
+			<article class="rounded-[1.75rem] border border-border/80 bg-card/75 p-6 transition-colors hover:border-primary/30 hover:bg-card">
+				<div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+					<div class="space-y-5 lg:max-w-3xl">
+						<div class="flex flex-wrap items-center gap-3">
+							<h2 class="text-2xl font-bold sm:text-3xl">{topic.title}</h2>
+							<span class="rounded-full border border-border bg-background px-3 py-1 text-sm font-medium text-muted-foreground">
+								{topic.postCount} post{topic.postCount === 1 ? "" : "s"}
+							</span>
+						</div>
+
+						<p class="max-w-2xl text-base leading-8 text-muted-foreground">{topic.summary}</p>
+
+						<div class="flex flex-wrap gap-2">
+							{#each topic.focusAreas.slice(0, 3) as focusArea}
+								<span class="rounded-full border border-border/80 bg-muted/60 px-3 py-1 text-sm text-muted-foreground">
+									{focusArea}
+								</span>
+							{/each}
+						</div>
+
+						<div class="rounded-[1.25rem] border border-border/70 bg-background/80 p-4">
+							<p class="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">Latest post</p>
+							{#if topic.latestPost}
+								<div class="mt-2 space-y-1">
+									<a
+										class="text-lg font-semibold text-foreground underline-offset-4 hover:text-primary hover:underline"
+										href={`/blog/${topic.latestPost.slug}`}
+									>
+										{topic.latestPost.title}
+									</a>
+									<p class="text-sm text-muted-foreground">
+										Updated {formatDate(topic.latestPost.date)}
+									</p>
+								</div>
+							{:else}
+								<p class="mt-2 text-sm text-muted-foreground">This hub is waiting for its first post.</p>
+							{/if}
+						</div>
+					</div>
+
+					<div class="flex shrink-0 flex-col gap-3 lg:items-end">
+						<p class="max-w-xs text-sm leading-7 text-muted-foreground lg:text-right">
+							Follow this subject through the posts that define it, then branch deeper once you know the terrain.
+						</p>
+						<a
+							href={`/topics/${topic.slug}`}
+							class={cn(buttonVariants("outline"), "no-underline rounded-full px-5")}
+						>
+							Open hub
+						</a>
+					</div>
+				</div>
+			</article>
 		{/each}
 	</div>
 </section>

--- a/src/routes/topics/+page.ts
+++ b/src/routes/topics/+page.ts
@@ -1,0 +1,10 @@
+import { getPublishedPosts } from "$lib/posts"
+import { getTopicOverviewItems } from "$lib/taxonomy"
+
+export const load = () => {
+	return {
+		topics: getTopicOverviewItems(getPublishedPosts()),
+	}
+}
+
+export const prerender = true

--- a/src/routes/topics/[topic]/+page.svelte
+++ b/src/routes/topics/[topic]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser } from "$app/environment"
-	import { afterNavigate, goto } from "$app/navigation"
 	import ArchiveSearchInput from "$lib/components/archive/ArchiveSearchInput.svelte"
 	import PaginationNav from "$lib/components/archive/PaginationNav.svelte"
 	import BlogCard from "$lib/components/BlogCard.svelte"
@@ -115,7 +114,7 @@
 		return `${nextUrl.pathname}${nextUrl.search}`
 	}
 
-	function writeTopicUrl(query: string, pageNumber: number, replaceState = false) {
+	function writeTopicHistory(query: string, pageNumber: number, replaceState = false) {
 		const nextUrl = serializeTopicUrl(query, pageNumber)
 		const currentUrl = `${window.location.pathname}${window.location.search}`
 
@@ -123,7 +122,12 @@
 			return
 		}
 
-		goto(nextUrl, { replaceState, noScroll: true, keepFocus: true })
+		if (replaceState) {
+			window.history.replaceState(window.history.state, "", nextUrl)
+			return
+		}
+
+		window.history.pushState(window.history.state, "", nextUrl)
 	}
 
 	function handleSearchChange(value: string) {
@@ -136,7 +140,7 @@
 		currentPage = 1
 
 		if (browser) {
-			writeTopicUrl("", 1, true)
+			writeTopicHistory("", 1, true)
 		}
 	}
 
@@ -145,16 +149,21 @@
 		currentPage = clampedPage
 
 		if (browser) {
-			writeTopicUrl(normalizedSearchTerm, clampedPage, false)
+			writeTopicHistory(normalizedSearchTerm, clampedPage, false)
 		}
 	}
 
 	onMount(() => {
 		syncStateFromUrl()
-
-		afterNavigate(() => {
+		const handlePopState = () => {
 			syncStateFromUrl()
-		})
+		}
+
+		window.addEventListener("popstate", handlePopState)
+
+		return () => {
+			window.removeEventListener("popstate", handlePopState)
+		}
 	})
 
 	$effect(() => {
@@ -175,7 +184,7 @@
 
 		if (urlQuery !== normalizedSearchTerm) {
 			const timeoutId = window.setTimeout(() => {
-				writeTopicUrl(normalizedSearchTerm, 1, true)
+				writeTopicHistory(normalizedSearchTerm, 1, true)
 			}, 150)
 
 			return () => window.clearTimeout(timeoutId)
@@ -196,7 +205,7 @@
 			urlPage !== normalizedPage ||
 			(!showPagination && new URLSearchParams(window.location.search).has("page"))
 		) {
-			writeTopicUrl(normalizedSearchTerm, normalizedPage, true)
+			writeTopicHistory(normalizedSearchTerm, normalizedPage, true)
 		}
 	})
 </script>

--- a/src/routes/topics/[topic]/+page.svelte
+++ b/src/routes/topics/[topic]/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import BlogCard from "$lib/components/BlogCard.svelte"
+	import { title } from "$lib/config"
+	import { createSeo } from "$lib/seo"
+
+	let { data } = $props()
+
+	let seo = $derived(
+		createSeo({
+			path: `/topics/${data.topic.slug}`,
+			title: `${data.topic.title} | ${title}`,
+			description: data.topic.description,
+		})
+	)
+</script>
+
+<svelte:head>
+	<title>{seo.title}</title>
+
+	<link rel="canonical" href={seo.canonical} />
+	<meta name="description" content={seo.description} />
+
+	<meta property="og:type" content={seo.type} />
+	<meta property="og:url" content={seo.canonical} />
+	<meta property="og:title" content={seo.title} />
+	<meta property="og:description" content={seo.description} />
+	<meta property="og:site_name" content={title} />
+	<meta property="og:image" content={seo.image} />
+
+	<meta name="twitter:site" content="@McBride1105" />
+	<meta name="twitter:creator" content="@McBride1105" />
+	<meta name="twitter:title" content={seo.title} />
+	<meta name="twitter:description" content={seo.description} />
+	<meta name="twitter:card" content={seo.twitterCard} />
+	<meta name="twitter:image:src" content={seo.image} />
+</svelte:head>
+
+<section class="mx-auto mb-16 max-w-6xl p-4">
+	<header class="mb-10 rounded-lg border border-border bg-card p-6">
+		<p class="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Topic hub</p>
+		<h1 class="mb-4 text-4xl font-bold sm:text-5xl">{data.topic.title}</h1>
+		<p class="mb-6 max-w-3xl text-muted-foreground">{data.topic.description}</p>
+		<div class="flex flex-wrap gap-2">
+			{#each data.topic.focusAreas as focusArea}
+				<span class="rounded-full border border-border bg-muted px-3 py-1 text-sm">{focusArea}</span>
+			{/each}
+		</div>
+	</header>
+
+	<section>
+		<div class="mb-6 flex items-center justify-between gap-4">
+			<div>
+				<h2 class="text-2xl font-bold">Posts in this topic</h2>
+				<p class="text-muted-foreground">{data.posts.length} post{data.posts.length === 1 ? "" : "s"}</p>
+			</div>
+			<a class="font-medium text-primary underline-offset-4 hover:underline" href="/topics">
+				View all topic hubs
+			</a>
+		</div>
+
+		<ul class="flex flex-col items-center">
+			{#each data.posts as post}
+				<BlogCard {post} />
+			{/each}
+		</ul>
+	</section>
+</section>

--- a/src/routes/topics/[topic]/+page.svelte
+++ b/src/routes/topics/[topic]/+page.svelte
@@ -286,6 +286,12 @@
 				</button>
 			</div>
 		{:else}
+			{#if showPagination}
+				<div class="mb-6">
+					<PaginationNav currentPage={effectivePage} totalPages={totalPages} onPageChange={handlePageChange} />
+				</div>
+			{/if}
+
 			<ul class="flex flex-col items-center">
 				{#each paginatedPosts as post}
 					<BlogCard {post} variant="compact" />

--- a/src/routes/topics/[topic]/+page.svelte
+++ b/src/routes/topics/[topic]/+page.svelte
@@ -1,9 +1,28 @@
 <script lang="ts">
+	import { browser } from "$app/environment"
+	import { afterNavigate, goto } from "$app/navigation"
+	import ArchiveSearchInput from "$lib/components/archive/ArchiveSearchInput.svelte"
+	import PaginationNav from "$lib/components/archive/PaginationNav.svelte"
 	import BlogCard from "$lib/components/BlogCard.svelte"
 	import { title } from "$lib/config"
 	import { createSeo } from "$lib/seo"
+	import { formatDate } from "$lib/utils.js"
+	import { onMount } from "svelte"
+	import type { PageData } from "./$types"
 
-	let { data } = $props()
+	let { data }: { data: PageData } = $props()
+
+	const pageSize = 6
+	const searchThreshold = 5
+
+	function normalizeSearch(value: string) {
+		return value.trim()
+	}
+
+	function parsePage(value: string | null) {
+		const parsed = Number(value)
+		return Number.isInteger(parsed) && parsed > 0 ? parsed : 1
+	}
 
 	let seo = $derived(
 		createSeo({
@@ -12,6 +31,174 @@
 			description: data.topic.description,
 		})
 	)
+
+	let searchTerm = $state("")
+	let currentPage = $state(1)
+	let urlStateReady = $state(!browser)
+
+	let normalizedSearchTerm = $derived(normalizeSearch(searchTerm))
+	let showSearch = $derived(data.posts.length >= searchThreshold)
+	let filteredPosts = $derived(
+		data.posts.filter((post) => {
+			if (!normalizedSearchTerm) {
+				return true
+			}
+
+			const query = normalizedSearchTerm.toLowerCase()
+			const haystacks = [post.title, post.description, post.short ?? "", ...post.categories]
+
+			return haystacks.some((field) => field.toLowerCase().includes(query))
+		})
+	)
+	let totalPages = $derived(Math.max(1, Math.ceil(filteredPosts.length / pageSize)))
+	let effectivePage = $derived(Math.min(Math.max(currentPage, 1), totalPages))
+	let showPagination = $derived(filteredPosts.length > pageSize)
+	let paginatedPosts = $derived(
+		filteredPosts.slice((effectivePage - 1) * pageSize, effectivePage * pageSize)
+	)
+	let resultsLabel = $derived(
+		normalizedSearchTerm
+			? `${filteredPosts.length} result${filteredPosts.length === 1 ? "" : "s"} for "${normalizedSearchTerm}"`
+			: `${data.posts.length} post${data.posts.length === 1 ? "" : "s"}`
+	)
+	let pageLabel = $derived(showPagination ? `Page ${effectivePage} of ${totalPages}` : "")
+	let archiveDescription = $derived(
+		showPagination
+			? "Search within this topic or move page by page through the archive."
+			: showSearch
+				? "Use search to narrow this topic, then scan the posts in one focused view."
+				: "This topic is compact enough to browse in one view."
+	)
+
+	function getUrlState() {
+		if (!browser) {
+			return { query: "", page: 1 }
+		}
+
+		const searchParams = new URLSearchParams(window.location.search)
+
+		return {
+			query: normalizeSearch(searchParams.get("q") ?? ""),
+			page: parsePage(searchParams.get("page")),
+		}
+	}
+
+	function syncStateFromUrl() {
+		const { query, page } = getUrlState()
+
+		if (query !== normalizedSearchTerm) {
+			searchTerm = query
+		}
+
+		if (page !== currentPage) {
+			currentPage = page
+		}
+
+		urlStateReady = true
+	}
+
+	function serializeTopicUrl(query: string, pageNumber: number) {
+		const nextUrl = new URL(window.location.href)
+
+		if (query) {
+			nextUrl.searchParams.set("q", query)
+		} else {
+			nextUrl.searchParams.delete("q")
+		}
+
+		if (pageNumber > 1 && totalPages > 1) {
+			nextUrl.searchParams.set("page", String(pageNumber))
+		} else {
+			nextUrl.searchParams.delete("page")
+		}
+
+		return `${nextUrl.pathname}${nextUrl.search}`
+	}
+
+	function writeTopicUrl(query: string, pageNumber: number, replaceState = false) {
+		const nextUrl = serializeTopicUrl(query, pageNumber)
+		const currentUrl = `${window.location.pathname}${window.location.search}`
+
+		if (nextUrl === currentUrl) {
+			return
+		}
+
+		goto(nextUrl, { replaceState, noScroll: true, keepFocus: true })
+	}
+
+	function handleSearchChange(value: string) {
+		searchTerm = value
+		currentPage = 1
+	}
+
+	function clearSearch() {
+		searchTerm = ""
+		currentPage = 1
+
+		if (browser) {
+			writeTopicUrl("", 1, true)
+		}
+	}
+
+	function handlePageChange(nextPage: number) {
+		const clampedPage = Math.min(Math.max(nextPage, 1), totalPages)
+		currentPage = clampedPage
+
+		if (browser) {
+			writeTopicUrl(normalizedSearchTerm, clampedPage, false)
+		}
+	}
+
+	onMount(() => {
+		syncStateFromUrl()
+
+		afterNavigate(() => {
+			syncStateFromUrl()
+		})
+	})
+
+	$effect(() => {
+		if (currentPage < 1) {
+			currentPage = 1
+			return
+		}
+
+		if (currentPage > totalPages) {
+			currentPage = totalPages
+		}
+	})
+
+	$effect(() => {
+		if (!browser || !urlStateReady) return
+
+		const { query: urlQuery } = getUrlState()
+
+		if (urlQuery !== normalizedSearchTerm) {
+			const timeoutId = window.setTimeout(() => {
+				writeTopicUrl(normalizedSearchTerm, 1, true)
+			}, 150)
+
+			return () => window.clearTimeout(timeoutId)
+		}
+	})
+
+	$effect(() => {
+		if (!browser || !urlStateReady) return
+
+		const { query: urlQuery, page: urlPage } = getUrlState()
+		const normalizedPage = showPagination ? effectivePage : 1
+
+		if (urlQuery !== normalizedSearchTerm) {
+			return
+		}
+
+		if (
+			urlPage !== normalizedPage ||
+			(!showPagination && new URLSearchParams(window.location.search).has("page"))
+		) {
+			writeTopicUrl(normalizedSearchTerm, normalizedPage, true)
+		}
+	})
 </script>
 
 <svelte:head>
@@ -36,32 +223,78 @@
 </svelte:head>
 
 <section class="mx-auto mb-16 max-w-6xl p-4">
-	<header class="mb-10 rounded-lg border border-border bg-card p-6">
-		<p class="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Topic hub</p>
-		<h1 class="mb-4 text-4xl font-bold sm:text-5xl">{data.topic.title}</h1>
-		<p class="mb-6 max-w-3xl text-muted-foreground">{data.topic.description}</p>
-		<div class="flex flex-wrap gap-2">
+	<header class="mb-8 rounded-[2rem] border border-border/80 bg-card/75 p-6 md:p-8">
+		<a
+			class="inline-flex text-sm font-medium text-primary underline-offset-4 hover:underline"
+			href="/topics"
+		>
+			All topics
+		</a>
+		<p class="mt-4 text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">Topic hub</p>
+		<h1 class="mt-3 max-w-3xl text-4xl font-bold tracking-tight sm:text-5xl">{data.topic.title}</h1>
+		<p class="mt-4 max-w-3xl text-base leading-8 text-muted-foreground sm:text-lg">
+			{data.topic.description}
+		</p>
+		<div class="mt-6 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+			<span class="rounded-full border border-border bg-background px-3 py-1">
+				{data.posts.length} post{data.posts.length === 1 ? "" : "s"}
+			</span>
+			{#if data.latestActivityDate}
+				<span>Latest update: {formatDate(data.latestActivityDate)}</span>
+			{/if}
+		</div>
+		<div class="mt-6 flex flex-wrap gap-2">
 			{#each data.topic.focusAreas as focusArea}
-				<span class="rounded-full border border-border bg-muted px-3 py-1 text-sm">{focusArea}</span>
+				<span class="rounded-full border border-border bg-muted/70 px-3 py-1 text-sm">{focusArea}</span>
 			{/each}
 		</div>
 	</header>
 
-	<section>
-		<div class="mb-6 flex items-center justify-between gap-4">
-			<div>
-				<h2 class="text-2xl font-bold">Posts in this topic</h2>
-				<p class="text-muted-foreground">{data.posts.length} post{data.posts.length === 1 ? "" : "s"}</p>
-			</div>
-			<a class="font-medium text-primary underline-offset-4 hover:underline" href="/topics">
-				View all topic hubs
-			</a>
+	<section class="rounded-[1.75rem] border border-border/70 bg-background/40 p-6 md:p-8">
+		<div class="mb-6 space-y-2">
+			<h2 class="text-2xl font-bold sm:text-3xl">Browse posts</h2>
+			<p class="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">{archiveDescription}</p>
 		</div>
 
-		<ul class="flex flex-col items-center">
-			{#each data.posts as post}
-				<BlogCard {post} />
-			{/each}
-		</ul>
+		{#if showSearch}
+			<div class="mb-6 rounded-[1.5rem] border border-border/70 bg-card/70 p-4">
+				<ArchiveSearchInput
+					id="topic-search"
+					label={`Search posts in ${data.topic.title}`}
+					placeholder={`Search posts in ${data.topic.title}`}
+					value={searchTerm}
+					{resultsLabel}
+					{pageLabel}
+					onValueChange={handleSearchChange}
+					onClear={clearSearch}
+				/>
+			</div>
+		{/if}
+
+		{#if filteredPosts.length === 0}
+			<div class="rounded-[1.5rem] border border-dashed border-border bg-card/70 p-8 text-center">
+				<h3 class="text-xl font-bold">No posts matched</h3>
+				<p class="mx-auto mt-3 max-w-xl text-sm leading-7 text-muted-foreground sm:text-base">
+					Try a different keyword or clear the current search.
+				</p>
+				<button
+					type="button"
+					class="mt-5 inline-flex rounded-full border border-border px-4 py-2 text-sm font-medium transition-colors hover:border-primary/40 hover:text-primary"
+					onclick={clearSearch}
+				>
+					Clear search
+				</button>
+			</div>
+		{:else}
+			<ul class="flex flex-col items-center">
+				{#each paginatedPosts as post}
+					<BlogCard {post} variant="compact" />
+				{/each}
+			</ul>
+
+			{#if showPagination}
+				<PaginationNav currentPage={effectivePage} totalPages={totalPages} onPageChange={handlePageChange} />
+			{/if}
+		{/if}
 	</section>
 </section>

--- a/src/routes/topics/[topic]/+page.ts
+++ b/src/routes/topics/[topic]/+page.ts
@@ -1,7 +1,7 @@
 import { error } from "@sveltejs/kit"
 import type { LoadEvent } from "@sveltejs/kit"
 import { getPublishedPosts } from "$lib/posts"
-import { getPostsForTopic, getTopic } from "$lib/taxonomy"
+import { getPostsForTopic, getTopic, getTopicLatestDate } from "$lib/taxonomy"
 
 export const load = async ({ params }: LoadEvent) => {
 	const topicSlug = params.topic
@@ -20,6 +20,7 @@ export const load = async ({ params }: LoadEvent) => {
 
 	return {
 		topic,
+		latestActivityDate: getTopicLatestDate(posts),
 		posts,
 	}
 }

--- a/src/routes/topics/[topic]/+page.ts
+++ b/src/routes/topics/[topic]/+page.ts
@@ -1,0 +1,27 @@
+import { error } from "@sveltejs/kit"
+import type { LoadEvent } from "@sveltejs/kit"
+import { getPublishedPosts } from "$lib/posts"
+import { getPostsForTopic, getTopic } from "$lib/taxonomy"
+
+export const load = async ({ params }: LoadEvent) => {
+	const topicSlug = params.topic
+
+	if (!topicSlug) {
+		throw error(404, "Topic not found")
+	}
+
+	const topic = getTopic(topicSlug)
+
+	if (!topic) {
+		throw error(404, "Topic not found")
+	}
+
+	const posts = getPostsForTopic(getPublishedPosts(), topic.slug)
+
+	return {
+		topic,
+		posts,
+	}
+}
+
+export const prerender = true

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,27 @@
+User-agent: *
+Allow: /
+
+# Keep non-public or internal-only areas out of crawl.
+Disallow: /admin/
+Disallow: /drafts/
+Disallow: /preview/
+Disallow: /api/private/
+
+# Allow search-facing AI crawlers that can drive discovery and referral traffic.
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+# Block training crawlers by default while keeping search crawlers available.
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+Sitemap: https://jimmymcbride.dev/sitemap.xml


### PR DESCRIPTION
## Summary
- add a GEO foundation for the site with shared SEO helpers, canonical cleanup, JSON-LD, `robots.txt`, and expanded sitemap coverage
- normalize topic metadata, add `/topics` hub pages, and improve related-content surfaces for posts and archives
- add a repo-local GEO planning workspace plus evergreen content, prompt, measurement, and syndication docs
- refresh the first cohort seed post and remove the misleading public view-count display from blog posts

## Verification
- `plan check --project .`
- `bun run check`
- `bun run build`
